### PR TITLE
Fix URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Or you can run the web version locally by executing the `wasmJsBrowserRun` Gradl
 
 # Documentation
 
-Visit the project's Github Pages https://www.gabrieldrn.github.com/carbon-compose/ to get more information about the
+Visit the project's Github Pages https://gabrieldrn.github.io/carbon-compose/ to get more information about the
 project, some documentation, its API reference and the catalog app. 
 
 # Contributions


### PR DESCRIPTION
To fix this:

<img width="1398" alt="Screenshot 2024-10-26 at 12 40 47" src="https://github.com/user-attachments/assets/747df15a-0f80-41f1-90a5-f44f26c424c4">
