### PR TITLE
docs: add availability matrix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,3 +38,50 @@ continues and new versions are released. The project is currently in its major v
 many components as those documented on the official Carbon Design System website, version `1.0.0` will be released. As the
 Carbon Design System continues to evolve under the guidance of IBM's design teams, this Compose Multiplatform adaptation
 will be updated accordingly over time.
+
+## Component Availability Matrix
+
+List of the currently supported components:
+
+| Components         | Android  🤖 | iOS   | Desktop  🖥️ | wasmJs 🌐 |
+|--------------------|:-----------:|:------:|:------------:|:---------:|
+| Accordion          |             |        |              |           |
+| AI label           |             |        |              |           |
+| Breadcrumb         |             |        |              |           |
+| Button             |      ✅      |   ✅    |      ✅       |     ✅     |
+| Checkbox           |      ✅      |   ✅    |      ✅       |     ✅     |
+| Code snippet       |             |        |              |           |
+| Contained list     |             |        |              |           |
+| Content switcher   |             |        |              |           |
+| Data table         |             |        |              |           |
+| Date picker        |             |        |              |           |
+| Dropdown           |      ✅      |   ✅    |      ✅       |     ✅     |
+| File uploader      |             |        |              |           |
+| Form               |             |        |              |           |
+| Inline loading     |             |        |              |           |
+| Link               |             |        |              |           |
+| List               |             |        |              |           |
+| Loading            |      ✅      |   ✅    |      ✅       |     ✅     |
+| Menu               |             |        |              |           |
+| Menu buttons       |             |        |              |           |
+| Modal              |             |        |              |           |
+| Multi-Select       |      ✅      |   ✅    |      ✅       |     ✅     |
+| Notification       |             |        |              |           |
+| Number input       |             |        |              |           |
+| Pagination         |             |        |              |           |
+| Popover            |             |        |              |           |
+| Progress bar       |      ✅      |   ✅    |      ✅       |     ✅     |
+| Progress indicator |             |        |              |           |
+| Radio button       |      ✅      |   ✅    |      ✅       |     ✅     |
+| Search             |             |        |              |           |
+| Select             |             |        |              |           |
+| Slider             |             |        |              |           |
+| Structured list    |             |        |              |           |
+| Tabs               |             |        |              |           |
+| Tags               |      ✅      |   ✅    |      ✅       |     ✅     |
+| Text input         |      ✅      |   ✅    |      ✅       |     ✅     |
+| Tile               |             |        |              |           |
+| Toggle             |      ✅      |   ✅    |      ✅       |     ✅     |
+| Toggletip          |             |        |              |           |
+| Treeview           |             |        |              |           |
+| UI shell           |             |        |              |           |


### PR DESCRIPTION
Looking around the documentation, I couldn't find a list of the missing components at a glance so I made one with the various platform support.

I think it would be interesting to show the status of the project, maybe mark those still needed for `1.0`.