### PR TITLE
Fix Dropdown bottom border not being drawn crisply

### DIFF
--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/dropdown/base/DropdownField.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/dropdown/base/DropdownField.kt
@@ -169,10 +169,12 @@ internal fun DropdownField(
                 drawRect(fieldBackgroundColor)
 
                 if (state !is DropdownInteractiveState.Error) {
+                    // Canvas starts at 0.5px, so offset to draw a crisp line.
+                    val y = size.height + 0.5f
                     drawLine(
                         color = fieldBorderColor,
-                        start = Offset(0f, size.height),
-                        end = Offset(size.width, size.height),
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
                         strokeWidth = 1.dp.toPx()
                     )
                 }


### PR DESCRIPTION
Fixes #46 

### Before:
![image](https://github.com/user-attachments/assets/a7d4171c-e640-45f3-aeb8-7bdf80618da5)

### After:
![image](https://github.com/user-attachments/assets/ea2e33cc-9353-4437-ae11-b5ad4e3db637)

Tested on desktop (Windows 11) and web (Vivaldi).

## Context
It seems that, like on web, canvas drawing starts at 0.5px, like so:

![image](https://github.com/user-attachments/assets/4c44c39b-4e80-48b6-a2ec-471bd9f844c4)
(picture from https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Applying_styles_and_colors#a_linewidth_example)

So offsetting half a pixel makes the line crisp.