### PR TITLE
Add `TabList` component

### DIFF
--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
@@ -63,12 +63,10 @@ internal fun Tab(
             .background(
                 when (variant) {
                     TabVariant.Line -> Color.Transparent
-                    TabVariant.Contained -> {
-                        if (selected) {
-                            Carbon.theme.layer01
-                        } else {
-                            Carbon.theme.layerAccent01
-                        }
+                    TabVariant.Contained -> if (selected) {
+                        Carbon.theme.layer01
+                    } else {
+                        Carbon.theme.layerAccent01
                     }
                 }
             )

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
@@ -45,6 +45,7 @@ internal fun Tab(
     onClick: () -> Unit
 ) {
     val colors = TabColors.colors(variant)
+    val backgroundColor by colors.backgroundColor(isSelected = selected)
     val textColor by colors.tabLabelTextColor(
         isEnabled = item.enabled,
         isSelected = selected
@@ -59,8 +60,8 @@ internal fun Tab(
                 }
             )
             .width(IntrinsicSize.Max)
-            .background(if (selected) colors.backgroundColor else colors.backgroundColorSelected)
-            .clickable { onClick() }
+            .background(backgroundColor)
+            .clickable(enabled = item.enabled) { onClick() }
     ) {
         Text(
             modifier = Modifier

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
@@ -55,12 +56,7 @@ internal fun Tab(
 
     Box(
         Modifier
-            .height(
-                when (variant) {
-                    TabVariant.Line -> SpacingScale.spacing08
-                    TabVariant.Contained -> SpacingScale.spacing09
-                }
-            )
+            .height(variant.height)
             .width(IntrinsicSize.Max)
             .background(backgroundColor)
             .drawBehind {
@@ -80,6 +76,7 @@ internal fun Tab(
                 }
             }
             .clickable(enabled = item.enabled) { onClick() }
+            .testTag(TabListTestTags.TAB_ROOT)
     ) {
         Text(
             modifier = Modifier

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
@@ -27,9 +27,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
@@ -37,19 +37,18 @@ import com.gabrieldrn.carbon.foundation.text.Text
 
 @Composable
 internal fun Tab(
-    label: String,
-    enabled: Boolean,
+    item: TabItem,
     selected: Boolean,
     beforeSelected: Boolean,
     isLast: Boolean,
     variant: TabVariant,
     onClick: () -> Unit
 ) {
-    val textColor = if (selected) {
-        Carbon.theme.textPrimary
-    } else {
-        Carbon.theme.textSecondary
-    }
+    val colors = TabColors.colors(variant)
+    val textColor by colors.tabLabelTextColor(
+        isEnabled = item.enabled,
+        isSelected = selected
+    )
 
     Box(
         Modifier
@@ -60,23 +59,14 @@ internal fun Tab(
                 }
             )
             .width(IntrinsicSize.Max)
-            .background(
-                when (variant) {
-                    TabVariant.Line -> Color.Transparent
-                    TabVariant.Contained -> if (selected) {
-                        Carbon.theme.layer01
-                    } else {
-                        Carbon.theme.layerAccent01
-                    }
-                }
-            )
+            .background(if (selected) colors.backgroundColor else colors.backgroundColorSelected)
             .clickable { onClick() }
     ) {
         Text(
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(horizontal = SpacingScale.spacing05),
-            text = label,
+            text = item.label,
             style = if (selected) {
                 Carbon.typography.headingCompact01.copy(textColor)
             } else {
@@ -98,7 +88,7 @@ internal fun Tab(
                         if (selected) {
                             Carbon.theme.borderInteractive
                         } else {
-                            Carbon.theme.borderSubtle00
+                            colors.bottomBorderUnselected
                         }
                     )
             )
@@ -109,7 +99,7 @@ internal fun Tab(
                     .align(Alignment.CenterEnd)
                     .width(1.dp)
                     .fillMaxHeight()
-                    .background(Carbon.theme.borderStrong01)
+                    .background(colors.verticalBorderUnselected)
             )
         }
     }

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
@@ -20,9 +20,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -30,6 +27,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
@@ -61,6 +63,22 @@ internal fun Tab(
             )
             .width(IntrinsicSize.Max)
             .background(backgroundColor)
+            .drawBehind {
+                when (variant) {
+                    TabVariant.Line -> drawIndicator(
+                        color = if (selected) colors.indicator else colors.bottomBorderUnselected,
+                        alignment = Alignment.Bottom
+                    )
+                    TabVariant.Contained -> {
+                        if (selected) {
+                            drawIndicator(color = colors.indicator, alignment = Alignment.Top)
+                        }
+                        if (!selected && !beforeSelected && !isLast) {
+                            drawSeparator(colors.verticalBorderUnselected)
+                        }
+                    }
+                }
+            }
             .clickable(enabled = item.enabled) { onClick() }
     ) {
         Text(
@@ -74,34 +92,31 @@ internal fun Tab(
                 Carbon.typography.bodyCompact01.copy(textColor)
             }
         )
-        if (variant == TabVariant.Line || selected) {
-            Spacer(
-                Modifier
-                    .align(
-                        when (variant) {
-                            TabVariant.Line -> Alignment.BottomCenter
-                            TabVariant.Contained -> Alignment.TopCenter
-                        }
-                    )
-                    .height(2.dp)
-                    .fillMaxWidth()
-                    .background(
-                        if (selected) {
-                            Carbon.theme.borderInteractive
-                        } else {
-                            colors.bottomBorderUnselected
-                        }
-                    )
-            )
-        }
-        if (variant == TabVariant.Contained && !selected && !beforeSelected && !isLast) {
-            Spacer(
-                Modifier
-                    .align(Alignment.CenterEnd)
-                    .width(1.dp)
-                    .fillMaxHeight()
-                    .background(colors.verticalBorderUnselected)
-            )
-        }
     }
+}
+
+private fun DrawScope.drawIndicator(
+    color: Color,
+    alignment: Alignment.Vertical
+) {
+    val y = when (alignment) {
+        Alignment.Top -> 0f
+        Alignment.Bottom -> size.height - 2.dp.toPx()
+        else -> error("Unsupported alignment: $alignment")
+    }
+    drawRect(
+        color = color,
+        topLeft = Offset(0f, y),
+        size = Size(width = size.width, height = 2.dp.toPx())
+    )
+}
+
+private fun DrawScope.drawSeparator(
+    color: Color
+) {
+    drawRect(
+        color = color,
+        topLeft = Offset(size.width - 1.dp.toPx(), 0f),
+        size = Size(width = 1.dp.toPx(), height = size.height)
+    )
 }

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
@@ -18,6 +18,7 @@ package com.gabrieldrn.carbon.tab
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.height
@@ -25,6 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -33,8 +35,10 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.Carbon
+import com.gabrieldrn.carbon.foundation.interaction.FocusIndication
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
 import com.gabrieldrn.carbon.foundation.text.Text
 
@@ -53,6 +57,7 @@ internal fun Tab(
         isEnabled = item.enabled,
         isSelected = selected
     )
+    val interactionSource = remember { MutableInteractionSource() }
 
     Box(
         Modifier
@@ -75,7 +80,13 @@ internal fun Tab(
                     }
                 }
             }
-            .clickable(enabled = item.enabled) { onClick() }
+            .clickable(
+                enabled = item.enabled,
+                onClick = onClick,
+                interactionSource = interactionSource,
+                indication = FocusIndication(Carbon.theme),
+                role = Role.Tab
+            )
             .testTag(TabListTestTags.TAB_ROOT)
     ) {
         Text(

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/Tab.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Jacob Ras
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.tab
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.gabrieldrn.carbon.Carbon
+import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
+import com.gabrieldrn.carbon.foundation.text.Text
+
+@Composable
+internal fun Tab(
+    label: String,
+    enabled: Boolean,
+    selected: Boolean,
+    beforeSelected: Boolean,
+    isLast: Boolean,
+    variant: TabVariant,
+    onClick: () -> Unit
+) {
+    val textColor = if (selected) {
+        Carbon.theme.textPrimary
+    } else {
+        Carbon.theme.textSecondary
+    }
+
+    Box(
+        Modifier
+            .height(
+                when (variant) {
+                    TabVariant.Line -> SpacingScale.spacing08
+                    TabVariant.Contained -> SpacingScale.spacing09
+                }
+            )
+            .width(IntrinsicSize.Max)
+            .background(
+                when (variant) {
+                    TabVariant.Line -> Color.Transparent
+                    TabVariant.Contained -> {
+                        if (selected) {
+                            Carbon.theme.layer01
+                        } else {
+                            Carbon.theme.layerAccent01
+                        }
+                    }
+                }
+            )
+            .clickable { onClick() }
+    ) {
+        Text(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(horizontal = SpacingScale.spacing05),
+            text = label,
+            style = if (selected) {
+                Carbon.typography.headingCompact01.copy(textColor)
+            } else {
+                Carbon.typography.bodyCompact01.copy(textColor)
+            }
+        )
+        if (variant == TabVariant.Line || selected) {
+            Spacer(
+                Modifier
+                    .align(
+                        when (variant) {
+                            TabVariant.Line -> Alignment.BottomCenter
+                            TabVariant.Contained -> Alignment.TopCenter
+                        }
+                    )
+                    .height(2.dp)
+                    .fillMaxWidth()
+                    .background(
+                        if (selected) {
+                            Carbon.theme.borderInteractive
+                        } else {
+                            Carbon.theme.borderSubtle00
+                        }
+                    )
+            )
+        }
+        if (variant == TabVariant.Contained && !selected && !beforeSelected && !isLast) {
+            Spacer(
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .width(1.dp)
+                    .fillMaxHeight()
+                    .background(Carbon.theme.borderStrong01)
+            )
+        }
+    }
+}

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Gabriel Derrien
+ * Copyright 2025 Jacob Ras
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.gabrieldrn.carbon.foundation.color.Theme
  *
  * @param theme The theme to use for the colors.
  * @param layer Current layer where the [TabList] is placed on.
+ * @param variant The visual variant of the tab.
  */
 @Immutable
 internal class TabColors private constructor(

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.tab
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.Color
+import com.gabrieldrn.carbon.Carbon
+import com.gabrieldrn.carbon.foundation.color.Layer
+import com.gabrieldrn.carbon.foundation.color.Theme
+
+/**
+ * The colors used by the [TabList] composable based on the current [theme].
+ *
+ * @param theme The theme to use for the colors.
+ * @param layer Current layer where the [TabList] is placed on.
+ */
+@Immutable
+internal class TabColors private constructor(
+    private val theme: Theme,
+    layer: Layer,
+    variant: TabVariant
+) {
+
+    val backgroundColor = when {
+        variant == TabVariant.Line -> Color.Transparent
+        layer == Layer.Layer00 -> theme.layer01
+        layer == Layer.Layer01 -> theme.layer02
+        else -> theme.layer03
+    }
+
+    val backgroundColorSelected = when {
+        variant == TabVariant.Line -> Color.Transparent
+        layer == Layer.Layer00 -> theme.layerAccent01
+        layer == Layer.Layer01 -> theme.layerAccent02
+        layer == Layer.Layer02 -> theme.layerAccent03
+        else -> theme.layerAccent03
+    }
+
+    val bottomBorderUnselected = when (layer) {
+        Layer.Layer00 -> theme.borderSubtle00
+        Layer.Layer01 -> theme.borderSubtle01
+        Layer.Layer02 -> theme.borderSubtle02
+        Layer.Layer03 -> theme.borderSubtle03
+    }
+
+    val verticalBorderUnselected = when (layer) {
+        Layer.Layer00 -> theme.borderStrong01
+        Layer.Layer01 -> theme.borderStrong02
+        Layer.Layer02, Layer.Layer03 -> theme.borderStrong03
+    }
+
+    @Composable
+    fun tabLabelTextColor(isEnabled: Boolean, isSelected: Boolean): State<Color> =
+        rememberUpdatedState(
+            newValue = with(theme) {
+                when {
+                    !isEnabled -> textDisabled
+                    isSelected -> textPrimary
+                    else -> textSecondary
+                }
+            }
+        )
+
+    internal companion object {
+
+        @Composable
+        fun colors(variant: TabVariant) = TabColors(Carbon.theme, Carbon.layer, variant)
+    }
+}

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
@@ -52,6 +52,8 @@ internal class TabColors private constructor(
         else -> theme.layer03
     }
 
+    val indicator = theme.borderInteractive
+
     val bottomBorderUnselected = when (layer) {
         Layer.Layer00 -> theme.borderSubtle01
         Layer.Layer01 -> theme.borderSubtle02

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabColors.kt
@@ -35,29 +35,27 @@ import com.gabrieldrn.carbon.foundation.color.Theme
 internal class TabColors private constructor(
     private val theme: Theme,
     layer: Layer,
-    variant: TabVariant
+    private val variant: TabVariant
 ) {
 
-    val backgroundColor = when {
+    private val backgroundColorUnselected = when {
+        variant == TabVariant.Line -> Color.Transparent
+        layer == Layer.Layer00 -> theme.layerAccent01
+        layer == Layer.Layer01 -> theme.layerAccent02
+        else -> theme.layerAccent03
+    }
+
+    private val backgroundColorSelected = when {
         variant == TabVariant.Line -> Color.Transparent
         layer == Layer.Layer00 -> theme.layer01
         layer == Layer.Layer01 -> theme.layer02
         else -> theme.layer03
     }
 
-    val backgroundColorSelected = when {
-        variant == TabVariant.Line -> Color.Transparent
-        layer == Layer.Layer00 -> theme.layerAccent01
-        layer == Layer.Layer01 -> theme.layerAccent02
-        layer == Layer.Layer02 -> theme.layerAccent03
-        else -> theme.layerAccent03
-    }
-
     val bottomBorderUnselected = when (layer) {
-        Layer.Layer00 -> theme.borderSubtle00
-        Layer.Layer01 -> theme.borderSubtle01
-        Layer.Layer02 -> theme.borderSubtle02
-        Layer.Layer03 -> theme.borderSubtle03
+        Layer.Layer00 -> theme.borderSubtle01
+        Layer.Layer01 -> theme.borderSubtle02
+        Layer.Layer02, Layer.Layer03 -> theme.borderSubtle03
     }
 
     val verticalBorderUnselected = when (layer) {
@@ -67,14 +65,22 @@ internal class TabColors private constructor(
     }
 
     @Composable
+    fun backgroundColor(isSelected: Boolean): State<Color> =
+        rememberUpdatedState(
+            newValue = when {
+                variant == TabVariant.Line -> Color.Transparent
+                isSelected -> backgroundColorSelected
+                else -> backgroundColorUnselected
+            }
+        )
+
+    @Composable
     fun tabLabelTextColor(isEnabled: Boolean, isSelected: Boolean): State<Color> =
         rememberUpdatedState(
-            newValue = with(theme) {
-                when {
-                    !isEnabled -> textDisabled
-                    isSelected -> textPrimary
-                    else -> textSecondary
-                }
+            newValue = when {
+                !isEnabled -> theme.textDisabled
+                isSelected -> theme.textPrimary
+                else -> theme.textSecondary
             }
         )
 

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabItem.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabItem.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Jacob Ras
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.tab
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Represents a single tab in a [TabList] component.
+ * @param label The label of the tab to be displayed.
+ * @param enabled Whether the tab is enabled or not.
+ */
+@Immutable
+public data class TabItem(
+    val label: String,
+    val enabled: Boolean = true
+)

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabItem.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabItem.kt
@@ -28,3 +28,8 @@ public data class TabItem(
     val label: String,
     val enabled: Boolean = true
 )
+
+/**
+ * Returns a map of strings to [TabItem]s.
+ */
+public fun tabItemsOf(vararg values: String): List<TabItem> = values.map { TabItem(it) }

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabList.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabList.kt
@@ -56,8 +56,7 @@ public fun TabList(
     ) {
         tabs.forEachIndexed { index, tab ->
             Tab(
-                label = tab.label,
-                enabled = tab.enabled,
+                item = tab,
                 selected = tab == selectedTab,
                 beforeSelected = selectedIndex - index == 1,
                 isLast = tabs.lastIndex == index,

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabList.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabList.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Jacob Ras
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.tab
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * # Tabs
+ *
+ * Tabs are used to organize related content. They allow the user to navigate between
+ * groups of information that appear within the same context.
+ *
+ * (From [Tabs documentation](https://carbondesignsystem.com/components/tabs/usage/))
+ *
+ * @param tabs The items to display as tabs.
+ * @param selectedTab The currently selected tab, usually the first one.
+ * @param onTabSelected Callback invoked when a tab is selected. The selected [TabItem] is
+ * passed as a parameter, and the callback should be used to update a remembered state with
+ * the new value.
+ * @param variant The variant of the tab list.
+ */
+@Composable
+public fun TabList(
+    tabs: List<TabItem>,
+    selectedTab: TabItem,
+    onTabSelected: (TabItem) -> Unit,
+    modifier: Modifier = Modifier,
+    variant: TabVariant = TabVariant.Line
+) {
+    val selectedIndex = tabs.indexOf(selectedTab)
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = when (variant) {
+            TabVariant.Line -> Arrangement.spacedBy(1.dp)
+            TabVariant.Contained -> Arrangement.Start
+        }
+    ) {
+        tabs.forEachIndexed { index, tab ->
+            Tab(
+                label = tab.label,
+                enabled = tab.enabled,
+                selected = tab == selectedTab,
+                beforeSelected = selectedIndex - index == 1,
+                isLast = tabs.lastIndex == index,
+                variant = variant,
+                onClick = { onTabSelected(tab) }
+            )
+        }
+    }
+}

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabListTestTags.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabListTestTags.kt
@@ -16,25 +16,6 @@
 
 package com.gabrieldrn.carbon.tab
 
-import androidx.compose.ui.unit.Dp
-import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
-
-/**
- * Visual variant of a [TabList].
- */
-public enum class TabVariant(
-    internal val height: Dp
-) {
-
-    /**
-     * A standalone tab that can also be nested within components. It is commonly used within
-     * components or for content using the entire page for layout, not connected to
-     * any other components.
-     */
-    Line(height = SpacingScale.spacing08),
-
-    /**
-     * An emphasized tab that is commonly used for defined content areas.
-     */
-    Contained(height = SpacingScale.spacing09)
+internal object TabListTestTags {
+    const val TAB_ROOT = "carbon_tab_root"
 }

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabVariant.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/tab/TabVariant.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Jacob Ras
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.tab
+
+/**
+ * Visual variant of a [TabList].
+ */
+public enum class TabVariant {
+
+    /**
+     * A standalone tab that can also be nested within components. It is commonly used within
+     * components or for content using the entire page for layout, not connected to
+     * any other components.
+     */
+    Line,
+
+    /**
+     * An emphasized tab that is commonly used for defined content areas.
+     */
+    Contained
+}

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/tab/TabListTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/tab/TabListTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Jacob Ras
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.tab
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.isFocusable
+import androidx.compose.ui.test.isNotFocusable
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.toList
+import kotlin.test.Test
+
+class TabListTest {
+
+    private var _variant by mutableStateOf(TabVariant.Line)
+
+    private val rootTag = "root"
+
+    @Test
+    fun tabList_validateLayout() = runComposeUiTest {
+        setContent {
+            CarbonDesignSystem {
+                TabList(
+                    tabs = testTabItems,
+                    selectedTab = testTabItems[0],
+                    onTabSelected = {},
+                    modifier = Modifier.testTag(rootTag),
+                    variant = _variant
+                )
+            }
+        }
+
+        forEachParameter {
+            onNodeWithTag(rootTag)
+                .assertHeightIsEqualTo(_variant.height)
+
+            onAllNodesWithTag(TabListTestTags.TAB_ROOT)
+                .toList()
+                .onEachIndexed { index, node ->
+                    val testTabItem = testTabItems[index]
+                    if (testTabItem.enabled) {
+                        node.assert(isFocusable())
+                    } else {
+                        node.assert(isNotFocusable())
+                    }
+                }
+        }
+    }
+
+    private fun forEachParameter(
+        testBlock: () -> Unit
+    ) {
+        TabVariant.entries.forEach { variant ->
+            println("Running test with variant = $variant")
+            _variant = variant
+
+            testBlock()
+        }
+    }
+}
+
+private val testTabItems = listOf(
+    TabItem(label = "Dashboard"),
+    TabItem(label = "Monitoring"),
+    TabItem(label = "Activity"),
+    TabItem(label = "Disabled", enabled = false)
+)

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/Destination.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/Destination.kt
@@ -18,6 +18,7 @@ package com.gabrieldrn.carbon.catalog
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.gabrieldrn.carbon.catalog.Destination.entries
 import com.gabrieldrn.carbon.catalog.buttons.ButtonDemoScreen
 import com.gabrieldrn.carbon.catalog.checkbox.CheckboxDemoScreen
 import com.gabrieldrn.carbon.catalog.contentswitcher.ContentSwitcherDemoScreen
@@ -27,6 +28,7 @@ import com.gabrieldrn.carbon.catalog.progressbar.ProgressBarDemoScreen
 import com.gabrieldrn.carbon.catalog.radiobutton.LoadingDemoScreen
 import com.gabrieldrn.carbon.catalog.radiobutton.RadioButtonDemoScreen
 import com.gabrieldrn.carbon.catalog.settings.SettingsScreen
+import com.gabrieldrn.carbon.catalog.tab.TabListDemoScreen
 import com.gabrieldrn.carbon.catalog.tag.TagDemoScreen
 import com.gabrieldrn.carbon.catalog.textinput.TextInputDemoScreen
 import com.gabrieldrn.carbon.catalog.toggle.ToggleDemoScreen
@@ -128,7 +130,11 @@ enum class Destination(
     Select("Select"),
     Slider("Slider"),
     StructuredList("Structured list"),
-    Tabs("Tabs"),
+    Tabs(
+        title = "Tabs",
+        route = "tabs",
+        content = { modifier -> TabListDemoScreen(modifier = modifier) }
+    ),
     Tag(
         title = "Tag",
         illustration = Res.drawable.tile_tag,

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/tab/TabListDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/tab/TabListDemoScreen.kt
@@ -49,7 +49,6 @@ import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
 import com.gabrieldrn.carbon.tab.TabItem
 import com.gabrieldrn.carbon.tab.TabList
 import com.gabrieldrn.carbon.tab.TabVariant
-import com.gabrieldrn.carbon.tab.tabItemsOf
 
 @Composable
 internal fun TabListDemoScreen(modifier: Modifier = Modifier) {
@@ -76,10 +75,10 @@ internal fun TabListDemoScreen(modifier: Modifier = Modifier) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                var selectedTab by remember { mutableStateOf(TabItem("Dashboard")) }
+                var selectedTab by remember { mutableStateOf(demoTabs[0]) }
 
                 TabList(
-                    tabs = tabItemsOf("Dashboard", "Monitoring", "Activity"),
+                    tabs = demoTabs,
                     selectedTab = selectedTab,
                     onTabSelected = { selectedTab = it },
                     variant = variantState
@@ -119,6 +118,12 @@ internal fun TabListDemoScreen(modifier: Modifier = Modifier) {
     }
 }
 
+private val demoTabs = listOf(
+    TabItem(label = "Dashboard"),
+    TabItem(label = "Monitoring"),
+    TabItem(label = "Activity"),
+    TabItem(label = "Disabled", enabled = false)
+)
 private val layersOptions =
     Layer.entries.associateWith { DropdownOption(it.toString(), enabled = it != Layer.Layer03) }
 private val tabVariants = TabVariant.entries.toDropdownOptions()

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/tab/TabListDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/tab/TabListDemoScreen.kt
@@ -119,5 +119,6 @@ internal fun TabListDemoScreen(modifier: Modifier = Modifier) {
     }
 }
 
-private val layersOptions = Layer.entries.associateWith { DropdownOption(it.toString()) }
+private val layersOptions =
+    Layer.entries.associateWith { DropdownOption(it.toString(), enabled = it != Layer.Layer03) }
 private val tabVariants = TabVariant.entries.toDropdownOptions()

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/tab/TabListDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/tab/TabListDemoScreen.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Jacob Ras
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.catalog.tab
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.gabrieldrn.carbon.Carbon
+import com.gabrieldrn.carbon.catalog.misc.LayerSelectionDropdown
+import com.gabrieldrn.carbon.dropdown.Dropdown
+import com.gabrieldrn.carbon.dropdown.base.DropdownOption
+import com.gabrieldrn.carbon.dropdown.base.toDropdownOptions
+import com.gabrieldrn.carbon.foundation.color.CarbonLayer
+import com.gabrieldrn.carbon.foundation.color.Layer
+import com.gabrieldrn.carbon.foundation.color.containerBackground
+import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
+import com.gabrieldrn.carbon.tab.TabItem
+import com.gabrieldrn.carbon.tab.TabList
+import com.gabrieldrn.carbon.tab.TabVariant
+import com.gabrieldrn.carbon.tab.tabItemsOf
+
+@Composable
+internal fun TabListDemoScreen(modifier: Modifier = Modifier) {
+    var layer by rememberSaveable { mutableStateOf(Layer.Layer00) }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .containerBackground()
+            .verticalScroll(state = rememberScrollState())
+            .padding(WindowInsets.navigationBars.asPaddingValues())
+    ) {
+        var variantState by rememberSaveable {
+            mutableStateOf(TabVariant.Line)
+        }
+
+        CarbonLayer(layer = layer) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .containerBackground()
+                    .padding(SpacingScale.spacing05),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                var selectedTab by remember { mutableStateOf(TabItem("Dashboard")) }
+
+                TabList(
+                    tabs = tabItemsOf("Dashboard", "Monitoring", "Activity"),
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                    variant = variantState
+                )
+            }
+        }
+
+        CarbonLayer {
+            Column(
+                modifier = Modifier
+                    .padding(SpacingScale.spacing05)
+                    .containerBackground()
+                    .padding(SpacingScale.spacing05),
+                verticalArrangement = Arrangement.spacedBy(SpacingScale.spacing04)
+            ) {
+                BasicText(
+                    text = "Configuration",
+                    style = Carbon.typography.heading02.copy(color = Carbon.theme.textPrimary)
+                )
+
+                Dropdown(
+                    placeholder = "Choose option",
+                    label = "TabList variant",
+                    options = tabVariants,
+                    selectedOption = variantState,
+                    onOptionSelected = { variantState = it }
+                )
+
+                LayerSelectionDropdown(
+                    layers = layersOptions,
+                    selectedLayer = layer,
+                    onLayerSelected = { layer = it },
+                    modifier = Modifier.padding(top = SpacingScale.spacing03)
+                )
+            }
+        }
+    }
+}
+
+private val layersOptions = Layer.entries.associateWith { DropdownOption(it.toString()) }
+private val tabVariants = TabVariant.entries.toDropdownOptions()

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ List of the currently supported components:
 | Select             |             |        |              |           |
 | Slider             |             |        |              |           |
 | Structured list    |             |        |              |           |
-| Tabs               |             |        |              |           |
+| Tabs               |      ✅      |   ✅    |      ✅       |     ✅     |
 | Tags               |      ✅      |   ✅    |      ✅       |     ✅     |
 | Text input         |      ✅      |   ✅    |      ✅       |     ✅     |
 | Tile               |             |        |              |           |


### PR DESCRIPTION
## Description

Adds a `TabList` component according to the specs at https://carbondesignsystem.com/components/tabs/usage/

Included: _Line_ and _Contained_ variant. Not included: _Vertical_ variant, dismissible tabs, secondary label, icons, any overflow thoughts.

### Tested on:

- [X] Android
- [ ] Desktop (Linux)
- [ ] Desktop (Mac OS)
- [X] Desktop (Windows)
- [ ] iOS (not yet, I'm upgrading my Mac Mini so it can run the latest XCode)
- [X] Web

## Screenshot / recording

![CarbonTabList](https://github.com/user-attachments/assets/9677163e-f8bc-4907-a9e4-8a991c69f1d4)