### PR TITLE
Inline Notification variant implementation

### DIFF
--- a/carbon/api/android/carbon.api
+++ b/carbon/api/android/carbon.api
@@ -948,10 +948,8 @@ public final class com/gabrieldrn/carbon/notification/CalloutNotificationKt {
 	public static final fun CalloutNotification (Ljava/lang/String;Lcom/gabrieldrn/carbon/notification/NotificationStatus;Landroidx/compose/ui/Modifier;Ljava/lang/String;ZLandroidx/compose/runtime/Composer;II)V
 }
 
-public final class com/gabrieldrn/carbon/notification/ComposableSingletons$CalloutNotificationKt {
-	public static final field INSTANCE Lcom/gabrieldrn/carbon/notification/ComposableSingletons$CalloutNotificationKt;
-	public fun <init> ()V
-	public final fun getLambda-1$carbon_release ()Lkotlin/jvm/functions/Function3;
+public final class com/gabrieldrn/carbon/notification/InlineNotificationKt {
+	public static final fun InlineNotification (Ljava/lang/String;Ljava/lang/String;Lcom/gabrieldrn/carbon/notification/NotificationStatus;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gabrieldrn/carbon/notification/NotificationStatus : java/lang/Enum {

--- a/carbon/api/desktop/carbon.api
+++ b/carbon/api/desktop/carbon.api
@@ -948,10 +948,8 @@ public final class com/gabrieldrn/carbon/notification/CalloutNotificationKt {
 	public static final fun CalloutNotification (Ljava/lang/String;Lcom/gabrieldrn/carbon/notification/NotificationStatus;Landroidx/compose/ui/Modifier;Ljava/lang/String;ZLandroidx/compose/runtime/Composer;II)V
 }
 
-public final class com/gabrieldrn/carbon/notification/ComposableSingletons$CalloutNotificationKt {
-	public static final field INSTANCE Lcom/gabrieldrn/carbon/notification/ComposableSingletons$CalloutNotificationKt;
-	public fun <init> ()V
-	public final fun getLambda-1$carbon ()Lkotlin/jvm/functions/Function3;
+public final class com/gabrieldrn/carbon/notification/InlineNotificationKt {
+	public static final fun InlineNotification (Ljava/lang/String;Ljava/lang/String;Lcom/gabrieldrn/carbon/notification/NotificationStatus;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gabrieldrn/carbon/notification/NotificationStatus : java/lang/Enum {

--- a/carbon/src/androidDebug/kotlin/com/gabrieldrn/carbon/notification/InlineNotificationPreview.kt
+++ b/carbon/src/androidDebug/kotlin/com/gabrieldrn/carbon/notification/InlineNotificationPreview.kt
@@ -17,49 +17,36 @@
 package com.gabrieldrn.carbon.notification
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.gabrieldrn.carbon.CarbonDesignSystem
-
-internal class NotificationStatusParameterProvider : PreviewParameterProvider<NotificationStatus> {
-    override val values = sequenceOf(
-        NotificationStatus.Informational,
-        NotificationStatus.Success,
-        NotificationStatus.Warning,
-        NotificationStatus.Error
-    )
-}
 
 @Preview(group = "Low contrast")
 @Composable
-private fun CalloutNotificationPreview(
+private fun InlineNotificationPreview(
     @PreviewParameter(NotificationStatusParameterProvider::class) status: NotificationStatus
 ) {
     CarbonDesignSystem {
-        CalloutNotification(
+        InlineNotification(
             title = "Callout Notification",
-            body = buildAnnotatedString {
-                append("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
-            },
-            status = status
+            body = "Lorem ipsum dolor.",
+            status = status,
+            onClose = {}
         )
     }
 }
 
 @Preview(group = "High contrast")
 @Composable
-private fun CalloutNotificationHighContrastPreview(
+private fun InlineNotificationHighContrastPreview(
     @PreviewParameter(NotificationStatusParameterProvider::class) status: NotificationStatus
 ) {
     CarbonDesignSystem {
-        CalloutNotification(
+        InlineNotification(
             title = "Callout Notification",
-            body = buildAnnotatedString {
-                append("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
-            },
+            body = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             status = status,
+            onClose = {},
             highContrast = true
         )
     }

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/ButtonFocusIndication.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/ButtonFocusIndication.kt
@@ -27,14 +27,16 @@ import com.gabrieldrn.carbon.foundation.motion.Motion
 
 internal class ButtonFocusIndication(
     private val theme: Theme,
-    private val buttonType: ButtonType
+    private val buttonType: ButtonType,
+    private val useInverseColor: Boolean = false
 ) : FocusIndication(theme) {
 
     private class ButtonIndicationInstance(
         interactionSource: InteractionSource,
         theme: Theme,
-        buttonType: ButtonType
-    ) : DefaultFocusIndicationInstance(interactionSource, theme) {
+        buttonType: ButtonType,
+        useInverseColor: Boolean = false
+    ) : DefaultFocusIndicationInstance(interactionSource, theme, useInverseColor) {
 
         override val insetFocusColor = if (buttonType == ButtonType.Ghost) {
             Color.Transparent
@@ -49,7 +51,7 @@ internal class ButtonFocusIndication(
     }
 
     override fun create(interactionSource: InteractionSource): DelegatableNode =
-        ButtonIndicationInstance(interactionSource, theme, buttonType)
+        ButtonIndicationInstance(interactionSource, theme, buttonType, useInverseColor)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/foundation/interaction/FocusIndication.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/foundation/interaction/FocusIndication.kt
@@ -39,7 +39,8 @@ internal open class FocusIndication(private val theme: Theme) : IndicationNodeFa
     internal open class DefaultFocusIndicationInstance(
         interactionSource: InteractionSource,
         theme: Theme,
-    ) : FocusIndicationInstance(interactionSource, theme) {
+        useInverseColor: Boolean = false
+    ) : FocusIndicationInstance(interactionSource, theme, useInverseColor) {
 
         override val focusAnimationSpec: FiniteAnimationSpec<Float> = snap()
 

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/foundation/interaction/FocusIndicationInstance.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/foundation/interaction/FocusIndicationInstance.kt
@@ -34,13 +34,14 @@ import kotlinx.coroutines.launch
 @Stable
 internal abstract class FocusIndicationInstance(
     protected val interactionSource: InteractionSource,
-    theme: Theme
+    theme: Theme,
+    useInverseColor: Boolean = false
 ) : Modifier.Node(), DrawModifierNode {
 
     protected val borderFocusWidth = 2f.dp
     protected val insetFocusWidth = 1f.dp
 
-    protected open val borderFocusColor = theme.focus
+    protected open val borderFocusColor = if (useInverseColor) theme.focusInverse else theme.focus
     protected open val insetFocusColor = Color.Transparent
 
     protected val focusAnimation = Animatable(0f)

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/foundation/text/CarbonTypography.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/foundation/text/CarbonTypography.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.unit.sp
 import co.touchlab.kermit.Logger
 import com.gabrieldrn.carbon.Res
@@ -214,7 +213,6 @@ public data class CarbonTypography(
         fontSize = 14.sp,
         lineHeight = 18.sp,
         letterSpacing = .16f.sp,
-        baselineShift = BaselineShift(.16f),
     )
 
     /**

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/CalloutNotification.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/CalloutNotification.kt
@@ -16,30 +16,18 @@
 
 package com.gabrieldrn.carbon.notification
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
-import com.gabrieldrn.carbon.icons.CheckmarkFilledIcon
-import com.gabrieldrn.carbon.icons.ErrorFilledIcon
-import com.gabrieldrn.carbon.icons.InformationFilledIcon
-import com.gabrieldrn.carbon.icons.WarningFilledIcon
 
 /**
  * # Callout notification
@@ -74,14 +62,10 @@ public fun CalloutNotification(
     )
 
     NotificationContainer(
+        status = status,
         colors = colors,
         modifier = modifier
     ) {
-        Icon(
-            status = status,
-            colors = colors,
-        )
-
         FlowRow(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalArrangement = Arrangement.spacedBy(2.dp),
@@ -138,72 +122,5 @@ public fun CalloutNotification(
         modifier = modifier,
         title = title,
         highContrast = highContrast
-    )
-}
-
-private val iconSize = 20.dp
-
-@Composable
-private fun Icon(
-    status: NotificationStatus,
-    colors: NotificationColors,
-    modifier: Modifier = Modifier
-) {
-    when (status) {
-        NotificationStatus.Informational -> InformationFilledIcon(
-            tint = colors.iconColor,
-            innerTint = colors.iconInnerColor,
-            size = iconSize,
-            modifier = modifier.testTag(NotificationTestTags.ICON_INFORMATIONAL)
-        )
-        NotificationStatus.Success -> CheckmarkFilledIcon(
-            tint = colors.iconColor,
-            size = iconSize,
-            modifier = modifier.testTag(NotificationTestTags.ICON_SUCCESS)
-        )
-        NotificationStatus.Warning -> WarningFilledIcon(
-            tint = colors.iconColor,
-            innerTint = colors.iconInnerColor,
-            size = iconSize,
-            modifier = modifier.testTag(NotificationTestTags.ICON_WARNING)
-        )
-        NotificationStatus.Error -> ErrorFilledIcon(
-            tint = colors.iconColor,
-            size = iconSize,
-            modifier = modifier.testTag(NotificationTestTags.ICON_ERROR)
-        )
-    }
-}
-
-@Composable
-private fun NotificationContainer(
-    colors: NotificationColors,
-    modifier: Modifier = Modifier,
-    content: @Composable RowScope.() -> Unit = {}
-) {
-    Row(
-        modifier = modifier
-            .background(colors.backgroundColor)
-            .drawWithContent {
-                drawContent()
-                val contourWidthPx = 1.dp.toPx()
-                drawRect(
-                    brush = SolidColor(colors.contourColor),
-                    topLeft = Offset(contourWidthPx / 2, contourWidthPx / 2),
-                    size = Size(
-                        size.width - contourWidthPx,
-                        size.height - contourWidthPx
-                    ),
-                    style = Stroke(1.dp.toPx())
-                )
-                drawRect(
-                    brush = SolidColor(colors.borderLeftColor),
-                    topLeft = Offset.Zero,
-                    size = Size(3f.dp.toPx(), size.height)
-                )
-            }
-            .padding(SpacingScale.spacing05)
-            .testTag(NotificationTestTags.CONTAINER),
-        content = content
     )
 }

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/CalloutNotification.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/CalloutNotification.kt
@@ -16,18 +16,9 @@
 
 package com.gabrieldrn.carbon.notification
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.unit.dp
-import com.gabrieldrn.carbon.Carbon
-import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
 
 /**
  * # Callout notification
@@ -47,7 +38,6 @@ import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
  * @param title The title of the notification.
  * @param highContrast Whether to use high contrast colors.
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 public fun CalloutNotification(
     body: AnnotatedString,
@@ -56,39 +46,14 @@ public fun CalloutNotification(
     title: String = "",
     highContrast: Boolean = false
 ) {
-    val colors = NotificationColors.rememberColors(
-        status = status,
-        useHighContrast = highContrast
-    )
-
     NotificationContainer(
+        body = body,
+        title = title,
         status = status,
-        colors = colors,
+        displayCloseButton = false,
+        highContrast = highContrast,
         modifier = modifier
-    ) {
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-            modifier = Modifier
-                .weight(1f)
-                .padding(start = SpacingScale.spacing05)
-        ) {
-            if (title.isNotBlank()) {
-                BasicText(
-                    text = title,
-                    style = Carbon.typography.headingCompact01,
-                    color = { colors.titleColor },
-                    modifier = Modifier.testTag(NotificationTestTags.TITLE)
-                )
-            }
-            BasicText(
-                text = body,
-                style = Carbon.typography.bodyCompact01,
-                color = { colors.bodyColor },
-                modifier = Modifier.testTag(NotificationTestTags.BODY)
-            )
-        }
-    }
+    )
 }
 
 /**

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/InlineNotification.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/InlineNotification.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.notification
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+
+/**
+ * # Inline notification
+ *
+ * Inline notifications show up in task flows, to notify users of the status of an action or system.
+ * They usually appear at the top of the primary content area or close to the item needing
+ * attention.
+ *
+ * (From [Notification documentation](https://carbondesignsystem.com/components/notification/usage/#inline))
+ *
+ * @param title The title of the notification.
+ * @param body The body of the notification.
+ * @param status The status of the notification, which determines its color and icon
+ * used.
+ * @param onClose The callback to be called when the notification is closed.
+ * @param modifier The modifier to apply to the component.
+ * @param highContrast Whether to use high contrast colors.
+ */
+@Composable
+public fun InlineNotification(
+    title: String,
+    body: String,
+    status: NotificationStatus,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    highContrast: Boolean = false
+) {
+    NotificationContainer(
+        body = AnnotatedString(body),
+        title = title,
+        status = status,
+        displayCloseButton = true,
+        highContrast = highContrast,
+        modifier = modifier,
+        onClose = onClose
+    )
+}

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
@@ -166,6 +166,7 @@ private fun CloseButton(
                 role = Role.Button
             )
             .padding(SpacingScale.spacing05)
+            .testTag(NotificationTestTags.CLOSE_BUTTON)
     ) {
         Image(
             painter = rememberVectorPainter(closeIcon),

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.notification
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
+import com.gabrieldrn.carbon.icons.CheckmarkFilledIcon
+import com.gabrieldrn.carbon.icons.ErrorFilledIcon
+import com.gabrieldrn.carbon.icons.InformationFilledIcon
+import com.gabrieldrn.carbon.icons.WarningFilledIcon
+
+private val iconSize = 20.dp
+
+@Composable
+internal fun NotificationContainer(
+    status: NotificationStatus,
+    colors: NotificationColors,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit = {}
+) {
+    Row(
+        modifier = modifier
+            .background(colors.backgroundColor)
+            .drawWithContent {
+                drawContent()
+                val contourWidthPx = 1.dp.toPx()
+                drawRect(
+                    brush = SolidColor(colors.contourColor),
+                    topLeft = Offset(contourWidthPx / 2, contourWidthPx / 2),
+                    size = Size(
+                        size.width - contourWidthPx,
+                        size.height - contourWidthPx
+                    ),
+                    style = Stroke(1.dp.toPx())
+                )
+                drawRect(
+                    brush = SolidColor(colors.borderLeftColor),
+                    topLeft = Offset.Zero,
+                    size = Size(3f.dp.toPx(), size.height)
+                )
+            }
+            .padding(SpacingScale.spacing05)
+            .testTag(NotificationTestTags.CONTAINER)
+    ) {
+        Icon(
+            status = status,
+            colors = colors,
+        )
+
+        content()
+    }
+}
+
+@Composable
+private fun Icon(
+    status: NotificationStatus,
+    colors: NotificationColors,
+    modifier: Modifier = Modifier
+) {
+    when (status) {
+        NotificationStatus.Informational -> InformationFilledIcon(
+            tint = colors.iconColor,
+            innerTint = colors.iconInnerColor,
+            size = iconSize,
+            modifier = modifier.testTag(NotificationTestTags.ICON_INFORMATIONAL)
+        )
+        NotificationStatus.Success -> CheckmarkFilledIcon(
+            tint = colors.iconColor,
+            size = iconSize,
+            modifier = modifier.testTag(NotificationTestTags.ICON_SUCCESS)
+        )
+        NotificationStatus.Warning -> WarningFilledIcon(
+            tint = colors.iconColor,
+            innerTint = colors.iconInnerColor,
+            size = iconSize,
+            modifier = modifier.testTag(NotificationTestTags.ICON_WARNING)
+        )
+        NotificationStatus.Error -> ErrorFilledIcon(
+            tint = colors.iconColor,
+            size = iconSize,
+            modifier = modifier.testTag(NotificationTestTags.ICON_ERROR)
+        )
+    }
+}

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
@@ -55,7 +55,9 @@ import com.gabrieldrn.carbon.icons.InformationFilledIcon
 import com.gabrieldrn.carbon.icons.WarningFilledIcon
 import com.gabrieldrn.carbon.icons.closeIcon
 
-private val iconSize = 20.dp
+// Required icon size from Carbon's documentation is 20px, however, when applying paddings of
+// 16px around it, this doesn't compute to a min size of 48px (16+16+20=52)
+private val iconSize = 18.dp
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationCommon.kt
@@ -16,34 +16,63 @@
 
 package com.gabrieldrn.carbon.notification
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import com.gabrieldrn.carbon.Carbon
+import com.gabrieldrn.carbon.button.ButtonFocusIndication
+import com.gabrieldrn.carbon.button.ButtonType
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
 import com.gabrieldrn.carbon.icons.CheckmarkFilledIcon
 import com.gabrieldrn.carbon.icons.ErrorFilledIcon
 import com.gabrieldrn.carbon.icons.InformationFilledIcon
 import com.gabrieldrn.carbon.icons.WarningFilledIcon
+import com.gabrieldrn.carbon.icons.closeIcon
 
 private val iconSize = 20.dp
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun NotificationContainer(
+    body: AnnotatedString,
+    title: String,
     status: NotificationStatus,
-    colors: NotificationColors,
+    displayCloseButton: Boolean,
+    highContrast: Boolean,
     modifier: Modifier = Modifier,
-    content: @Composable RowScope.() -> Unit = {}
+    onClose: () -> Unit = {},
 ) {
+    val colors = NotificationColors.rememberColors(
+        status = status,
+        useHighContrast = highContrast
+    )
+
     Row(
         modifier = modifier
             .background(colors.backgroundColor)
@@ -65,15 +94,85 @@ internal fun NotificationContainer(
                     size = Size(3f.dp.toPx(), size.height)
                 )
             }
-            .padding(SpacingScale.spacing05)
             .testTag(NotificationTestTags.CONTAINER)
     ) {
         Icon(
             status = status,
             colors = colors,
+            modifier = Modifier
+                .padding(start = SpacingScale.spacing05)
+                .padding(top = SpacingScale.spacing05)
         )
 
-        content()
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = SpacingScale.spacing05)
+                .padding(vertical = SpacingScale.spacing05)
+        ) {
+            if (title.isNotBlank()) {
+                BasicText(
+                    text = title,
+                    style = Carbon.typography.headingCompact01,
+                    color = { colors.titleColor },
+                    modifier = Modifier.testTag(NotificationTestTags.TITLE)
+                )
+            }
+            BasicText(
+                text = body,
+                style = Carbon.typography.bodyCompact01,
+                color = { colors.bodyColor },
+                modifier = Modifier.testTag(NotificationTestTags.BODY)
+            )
+        }
+
+        if (displayCloseButton) {
+            CloseButton(
+                onClick = onClose,
+                isHighContrast = highContrast
+            )
+        } else {
+            Spacer(modifier = Modifier.width(SpacingScale.spacing05))
+        }
+    }
+}
+
+@Composable
+private fun CloseButton(
+    onClick: () -> Unit,
+    isHighContrast: Boolean,
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val theme = Carbon.theme
+    val indication = remember(theme, isHighContrast) {
+        ButtonFocusIndication(
+            theme = theme,
+            buttonType = ButtonType.Ghost,
+            useInverseColor = isHighContrast
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .clickable(
+                interactionSource = interactionSource,
+                indication = indication,
+                onClick = onClick,
+                role = Role.Button
+            )
+            .padding(SpacingScale.spacing05)
+    ) {
+        Image(
+            painter = rememberVectorPainter(closeIcon),
+            contentDescription = "Close button",
+            colorFilter = ColorFilter.tint(
+                if (isHighContrast) theme.iconInverse else theme.iconPrimary
+            ),
+            modifier = Modifier.size(20.dp).align(Alignment.Center),
+        )
     }
 }
 

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationTestTags.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/notification/NotificationTestTags.kt
@@ -24,4 +24,5 @@ internal object NotificationTestTags {
     const val ICON_ERROR = "carbon_notification_icon_error"
     const val TITLE = "carbon_notification_title"
     const val BODY = "carbon_notification_body"
+    const val CLOSE_BUTTON = "carbon_notification_close_button"
 }

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/Parameterization.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/Parameterization.kt
@@ -28,6 +28,10 @@ in the same activity. This requires to use mutable states at class level to stor
 it's not ideal but it's a trade-off between execution time and code readability.
  */
 
+const val PARAMTRZD_DEPRECATION_MESSAGE =
+    "This paramaterization method is deprecated, use the common forEachParameter method instead."
+const val PARAMTRZD_DEPRECATION_REPLACE = "forEachParameter"
+
 inline fun <reified A : Any, reified B : Any> forEachParameter(
     aValues: Array<A>,
     bValues: Array<B>,

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/Parameterization.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/Parameterization.kt
@@ -29,7 +29,7 @@ it's not ideal but it's a trade-off between execution time and code readability.
  */
 
 const val PARAMTRZD_DEPRECATION_MESSAGE =
-    "This paramaterization method is deprecated, use the common forEachParameter method instead."
+    "This parameterization method is deprecated, use the common forEachParameter method instead."
 const val PARAMTRZD_DEPRECATION_REPLACE = "forEachParameter"
 
 inline fun <reified A : Any, reified B : Any> forEachParameter(

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/Parameterization.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/Parameterization.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("Unused", "NestedBlockDepth")
+
+package com.gabrieldrn.carbon
+
+import co.touchlab.kermit.Logger
+
+/*
+These methods are mainly used for compose UI testing to optimize the execution time of the tests.
+For Android, using a paramaterization library involves waiting for the activity to be recreated
+for each test case, which is really slow. Instead, these methods allow to run all the test cases
+in the same activity. This requires to use mutable states at class level to store the parameters,
+it's not ideal but it's a trade-off between execution time and code readability.
+ */
+
+inline fun <reified A : Any, reified B : Any> forEachParameter(
+    aValues: Array<A>,
+    bValues: Array<B>,
+    block: (A, B) -> Unit
+) {
+    val aTypeName = A::class.simpleName
+    val bTypeName = B::class.simpleName
+
+    aValues.forEach { a ->
+        bValues.forEach { b ->
+            Logger.d("$aTypeName: $a, $bTypeName: $b")
+            block(a, b)
+        }
+    }
+}
+
+inline fun <reified A : Any, reified B : Any, reified C : Any> forEachParameter(
+    aValues: Array<A>,
+    bValues: Array<B>,
+    cValues: Array<C>,
+    block: (A, B, C) -> Unit
+) {
+    val aTypeName = A::class.simpleName
+    val bTypeName = B::class.simpleName
+    val cTypeName = C::class.simpleName
+    aValues.forEach { a ->
+        bValues.forEach { b ->
+            cValues.forEach { c ->
+                Logger.d("$aTypeName: $a, $bTypeName: $b, $cTypeName: $c")
+                block(a, b, c)
+            }
+        }
+    }
+}
+
+inline fun <reified A : Any, reified B : Any, reified C : Any, reified D : Any> forEachParameter(
+    aValues: Array<A>,
+    bValues: Array<B>,
+    cValues: Array<C>,
+    dValues: Array<D>,
+    block: (A, B, C, D) -> Unit
+) {
+    val aTypeName = A::class.simpleName
+    val bTypeName = B::class.simpleName
+    val cTypeName = C::class.simpleName
+    val dTypeName = D::class.simpleName
+
+    aValues.forEach { a ->
+        bValues.forEach { b ->
+            cValues.forEach { c ->
+                dValues.forEach { d ->
+                    Logger.d("$aTypeName: $a, $bTypeName: $b, $cTypeName: $c, $dTypeName: $d")
+                    block(a, b, c, d)
+                }
+            }
+        }
+    }
+}

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/contentswitcher/ContentSwitcherTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/contentswitcher/ContentSwitcherTest.kt
@@ -49,6 +49,8 @@ import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_MESSAGE
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_REPLACE
 import com.gabrieldrn.carbon.icons.checkmarkFilledIcon
 import com.gabrieldrn.carbon.icons.closeIcon
 import com.gabrieldrn.carbon.icons.viewIcon
@@ -246,6 +248,11 @@ class ContentSwitcherTest {
         }
     }
 
+    @Deprecated(
+        message = PARAMTRZD_DEPRECATION_MESSAGE,
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(PARAMTRZD_DEPRECATION_REPLACE)
+    )
     private fun forEachParameter(
         testBlock: () -> Unit
     ) {

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/notification/CalloutNotificationTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/notification/CalloutNotificationTest.kt
@@ -23,10 +23,9 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
-import co.touchlab.kermit.Logger
 import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.forEachParameter
 import kotlin.test.Test
 
 class CalloutNotificationTest {
@@ -50,7 +49,16 @@ class CalloutNotificationTest {
             }
         }
 
-        forEachParameter1 { body, status, title, highContrast ->
+        forEachParameter(
+            arrayOf(
+                buildAnnotatedString {},
+                buildAnnotatedString { append("This is a callout notification.") }
+            ),
+            NotificationStatus.entries.toTypedArray(),
+            arrayOf("", "Callout notification"),
+            arrayOf(false, true)
+        ) { body, status, title, highContrast ->
+
             _annotatedStringBody = body
             _status = status
             _title = title
@@ -101,7 +109,13 @@ class CalloutNotificationTest {
             }
         }
 
-        forEachParameter2 { body, status, title, highContrast ->
+        forEachParameter(
+            arrayOf("", "This is a callout notification."),
+            NotificationStatus.entries.toTypedArray(),
+            arrayOf("", "Callout notification"),
+            arrayOf(false, true)
+        ) { body, status, title, highContrast ->
+
             _stringBody = body
             _status = status
             _title = title
@@ -134,51 +148,6 @@ class CalloutNotificationTest {
                 } else {
                     assertIsDisplayed()
                     assertTextEquals(body)
-                }
-            }
-        }
-    }
-
-    @Suppress("NestedBlockDepth")
-    private fun forEachParameter1(
-        testBlock: (AnnotatedString, NotificationStatus, String, Boolean) -> Unit
-    ) {
-        arrayOf(
-            buildAnnotatedString {},
-            buildAnnotatedString { append("This is a callout notification.") }
-        ).forEach { body ->
-            NotificationStatus.entries.forEach { status ->
-                arrayOf("", "Callout notification").forEach { title ->
-                    arrayOf(false, true).forEach { highContrast ->
-                        Logger.d(
-                            "body: $body, " +
-                                "status: $status, " +
-                                "title: $title, " +
-                                "highContrast: $highContrast"
-                        )
-                        testBlock(body, status, title, highContrast)
-                    }
-                }
-            }
-        }
-    }
-
-    @Suppress("NestedBlockDepth")
-    private fun forEachParameter2(
-        testBlock: (String, NotificationStatus, String, Boolean) -> Unit
-    ) {
-        arrayOf("", "This is a callout notification.").forEach { body ->
-            NotificationStatus.entries.forEach { status ->
-                arrayOf("", "Callout notification").forEach { title ->
-                    arrayOf(false, true).forEach { highContrast ->
-                        Logger.d(
-                            "body: $body, " +
-                                "status: $status, " +
-                                "title: $title, " +
-                                "highContrast: $highContrast"
-                        )
-                        testBlock(body, status, title, highContrast)
-                    }
                 }
             }
         }

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/notification/InlineNotificationTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/notification/InlineNotificationTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.notification
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.forEachParameter
+import kotlin.test.Test
+
+class InlineNotificationTest {
+
+    private var _body by mutableStateOf("")
+    private var _status by mutableStateOf(NotificationStatus.Informational)
+    private var _title by mutableStateOf("")
+    private var _highContrast by mutableStateOf(false)
+
+    @Test
+    fun inlineNotifications_validateLayout() = runComposeUiTest {
+        setContent {
+            CarbonDesignSystem {
+                InlineNotification(
+                    title = _title,
+                    body = _body,
+                    status = _status,
+                    onClose = {},
+                    highContrast = _highContrast,
+                )
+            }
+        }
+
+        forEachParameter(
+            arrayOf("", "This is an inline notification."),
+            NotificationStatus.entries.toTypedArray(),
+            arrayOf("", "Inline notification"),
+            arrayOf(false, true)
+        ) { body, status, title, highContrast ->
+
+            _body = body
+            _status = status
+            _title = title
+            _highContrast = highContrast
+
+            onNodeWithTag(NotificationTestTags.CONTAINER)
+                .assertIsDisplayed()
+
+            onNodeWithTag(
+                when (status) {
+                    NotificationStatus.Informational -> NotificationTestTags.ICON_INFORMATIONAL
+                    NotificationStatus.Success -> NotificationTestTags.ICON_SUCCESS
+                    NotificationStatus.Warning -> NotificationTestTags.ICON_WARNING
+                    NotificationStatus.Error -> NotificationTestTags.ICON_ERROR
+                }
+            ).assertIsDisplayed()
+
+            onNodeWithTag(NotificationTestTags.TITLE).run {
+                if (title.isBlank()) {
+                    assertDoesNotExist()
+                } else {
+                    assertIsDisplayed()
+                    assertTextEquals(title)
+                }
+            }
+
+            onNodeWithTag(NotificationTestTags.BODY).run {
+                if (body.isBlank()) {
+                    assertExists()
+                } else {
+                    assertIsDisplayed()
+                    assertTextEquals(body)
+                }
+            }
+
+            onNodeWithTag(NotificationTestTags.CLOSE_BUTTON)
+                .assertIsDisplayed()
+                .assertHasClickAction()
+        }
+    }
+}

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/progressbar/ProgressBarTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/progressbar/ProgressBarTest.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_MESSAGE
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_REPLACE
 import com.gabrieldrn.carbon.icons.checkmarkFilledIcon
 import com.gabrieldrn.carbon.icons.errorFilledIcon
 import kotlin.test.Test
@@ -143,6 +145,11 @@ class ProgressBarTest {
     }
 
     @Suppress("NestedBlockDepth")
+    @Deprecated(
+        message = PARAMTRZD_DEPRECATION_MESSAGE,
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(PARAMTRZD_DEPRECATION_REPLACE)
+    )
     private fun forEachParameter(
         testBlock: (String?, String?, Boolean, ProgressBarState) -> Unit
     ) {

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/tab/TabListTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/tab/TabListTest.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_MESSAGE
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_REPLACE
 import com.gabrieldrn.carbon.toList
 import kotlin.test.Test
 
@@ -75,6 +77,11 @@ class TabListTest {
         }
     }
 
+    @Deprecated(
+        message = PARAMTRZD_DEPRECATION_MESSAGE,
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(PARAMTRZD_DEPRECATION_REPLACE)
+    )
     private fun forEachParameter(
         testBlock: () -> Unit
     ) {

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/tag/ReadOnlyTagTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/tag/ReadOnlyTagTest.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_MESSAGE
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_REPLACE
 import kotlin.test.Test
 
 class ReadOnlyTagTest {
@@ -78,6 +80,11 @@ class ReadOnlyTagTest {
     }
 
     @Suppress("NestedBlockDepth")
+    @Deprecated(
+        message = PARAMTRZD_DEPRECATION_MESSAGE,
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(PARAMTRZD_DEPRECATION_REPLACE)
+    )
     private fun forEachParameter(
         testBlock: (String, (@Composable () -> Painter)?, TagType, TagSize) -> Unit
     ) {

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/textinput/PasswordInputTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/textinput/PasswordInputTest.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_MESSAGE
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_REPLACE
 import com.gabrieldrn.carbon.icons.viewIcon
 import com.gabrieldrn.carbon.icons.viewOffIcon
 import com.gabrieldrn.carbon.semantics.assertHasImageVector
@@ -152,6 +154,11 @@ class PasswordInputTest {
     }
 
     @Suppress("NestedBlockDepth")
+    @Deprecated(
+        message = PARAMTRZD_DEPRECATION_MESSAGE,
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(PARAMTRZD_DEPRECATION_REPLACE)
+    )
     private fun forEachParameter(
         testBlock: (String, Boolean, String, String, TextInputState) -> Unit
     ) {

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/textinput/TextInputTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/textinput/TextInputTest.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_MESSAGE
+import com.gabrieldrn.carbon.PARAMTRZD_DEPRECATION_REPLACE
 import com.gabrieldrn.carbon.semantics.isReadOnly
 import kotlin.test.Test
 
@@ -144,6 +146,11 @@ class TextInputTest {
     }
 
     @Suppress("NestedBlockDepth")
+    @Deprecated(
+        message = PARAMTRZD_DEPRECATION_MESSAGE,
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(PARAMTRZD_DEPRECATION_REPLACE)
+    )
     private fun forEachParameter(
         testBlock: (TextInputVariant, String, String, String, TextInputState) -> Unit
     ) {

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/notification/CalloutNotificationDemo.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/notification/CalloutNotificationDemo.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.catalog.notification
+
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import com.gabrieldrn.carbon.Carbon
+import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
+import com.gabrieldrn.carbon.notification.CalloutNotification
+import com.gabrieldrn.carbon.notification.NotificationStatus
+
+@Composable
+fun CalloutNotificationDemo(
+    title: String,
+    body: String,
+    notificationStatus: NotificationStatus,
+    highContrast: Boolean,
+) {
+    UrlDemoNotification(
+        notificationStatus = notificationStatus,
+        highContrast = highContrast,
+        modifier = Modifier.width(IntrinsicSize.Max)
+    )
+
+    Spacer(modifier = Modifier.height(SpacingScale.spacing05))
+
+    EditableDemoNotification(
+        title = title,
+        body = body,
+        notificationStatus = notificationStatus,
+        highContrast = highContrast,
+        modifier = Modifier.width(IntrinsicSize.Max)
+    )
+}
+
+@Composable
+private fun UrlDemoNotification(
+    notificationStatus: NotificationStatus,
+    highContrast: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val url = remember {
+        "https://carbondesignsystem.com/components/notification/usage/#callout"
+    }
+
+    CalloutNotification(
+        title = "Callout notification",
+        body = buildAnnotatedString {
+            val clickableText = "callout notification"
+            val string = "This is a $clickableText."
+            append(string)
+            addLink(
+                url = LinkAnnotation.Url(
+                    url = url,
+                    styles = TextLinkStyles(
+                        style = SpanStyle(
+                            color = Carbon.theme.linkPrimary,
+                            textDecoration = TextDecoration.Underline
+                        )
+                    ),
+                ),
+                start = string.indexOf(clickableText),
+                end = string.indexOf(clickableText) + clickableText.length
+            )
+        },
+        status = notificationStatus,
+        highContrast = highContrast,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun EditableDemoNotification(
+    title: String,
+    body: String,
+    notificationStatus: NotificationStatus,
+    highContrast: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    CalloutNotification(
+        title = title,
+        body = body,
+        status = notificationStatus,
+        highContrast = highContrast,
+        modifier = modifier.width(IntrinsicSize.Max)
+    )
+}

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/notification/NotificationDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/notification/NotificationDemoScreen.kt
@@ -17,8 +17,11 @@
 package com.gabrieldrn.carbon.catalog.notification
 
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -26,8 +29,10 @@ import androidx.compose.ui.Modifier
 import com.gabrieldrn.carbon.catalog.common.DemoScreen
 import com.gabrieldrn.carbon.dropdown.Dropdown
 import com.gabrieldrn.carbon.dropdown.base.toDropdownOptions
+import com.gabrieldrn.carbon.notification.InlineNotification
 import com.gabrieldrn.carbon.notification.NotificationStatus
 import com.gabrieldrn.carbon.tab.TabItem
+import com.gabrieldrn.carbon.textinput.TextArea
 import com.gabrieldrn.carbon.textinput.TextInput
 import com.gabrieldrn.carbon.toggle.Toggle
 
@@ -44,9 +49,7 @@ fun NotificationDemoScreen(
 ) {
     var notificationStatus by remember { mutableStateOf(NotificationStatus.Success) }
     var highContrast by remember { mutableStateOf(false) }
-    var title by remember {
-        mutableStateOf("Lorem ipsum")
-    }
+    var title by remember { mutableStateOf("Lorem ipsum") }
     var body by remember {
         mutableStateOf("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
     }
@@ -59,7 +62,7 @@ fun NotificationDemoScreen(
             placeholderText = "Enter a title"
         )
 
-        TextInput(
+        TextArea(
             label = "Body",
             value = body,
             onValueChange = { body = it },
@@ -84,13 +87,31 @@ fun NotificationDemoScreen(
     DemoScreen(
         variants = variants,
         modifier = modifier,
-        demoContent = {
-            CalloutNotificationDemo(
-                title = title,
-                body = body,
-                notificationStatus = notificationStatus,
-                highContrast = highContrast
-            )
+        demoContent = { variant ->
+            when (NotificationVariant.valueOf(variant.label)) {
+                NotificationVariant.Callout -> CalloutNotificationDemo(
+                    title = title,
+                    body = body,
+                    notificationStatus = notificationStatus,
+                    highContrast = highContrast
+                )
+
+                NotificationVariant.Inline ->
+                    // Usage of this key fixes an issue with the focus indication color when
+                    // changing the high contrast parameter. Although the focus indication instance
+                    // is set to be re-calculated when the high contrast parameter changes, the
+                    // rendered color is not updated.
+                    key(highContrast) {
+                        InlineNotification(
+                            title = title,
+                            body = body,
+                            status = notificationStatus,
+                            onClose = {},
+                            modifier = Modifier.width(IntrinsicSize.Max),
+                            highContrast = highContrast
+                        )
+                    }
+            }
         },
         demoParametersContent = parametersContent,
         displayVariantsWIPNotification = true

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/notification/NotificationDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/notification/NotificationDemoScreen.kt
@@ -17,67 +17,33 @@
 package com.gabrieldrn.carbon.catalog.notification
 
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.style.TextDecoration
-import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.catalog.common.DemoScreen
 import com.gabrieldrn.carbon.dropdown.Dropdown
 import com.gabrieldrn.carbon.dropdown.base.toDropdownOptions
-import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
-import com.gabrieldrn.carbon.notification.CalloutNotification
 import com.gabrieldrn.carbon.notification.NotificationStatus
+import com.gabrieldrn.carbon.tab.TabItem
 import com.gabrieldrn.carbon.textinput.TextInput
 import com.gabrieldrn.carbon.toggle.Toggle
 
-@Composable
-fun NotificationDemoScreen(modifier: Modifier = Modifier) {
+private enum class NotificationVariant {
+    Callout,
+    Inline
+}
 
+private val variants = NotificationVariant.entries.map { TabItem(it.name) }
+
+@Composable
+fun NotificationDemoScreen(
+    modifier: Modifier = Modifier
+) {
     var notificationStatus by remember { mutableStateOf(NotificationStatus.Success) }
     var highContrast by remember { mutableStateOf(false) }
-
-    val urlDemoNotification: @Composable ColumnScope.() -> Unit = {
-        val url = remember {
-            "https://carbondesignsystem.com/components/notification/usage/#callout"
-        }
-        CalloutNotification(
-            title = "Callout notification",
-            body = buildAnnotatedString {
-                val clickableText = "callout notification"
-                val string = "This is a $clickableText."
-                append(string)
-                addLink(
-                    url = LinkAnnotation.Url(
-                        url = url,
-                        styles = TextLinkStyles(
-                            style = SpanStyle(
-                                color = Carbon.theme.linkPrimary,
-                                textDecoration = TextDecoration.Underline
-                            )
-                        ),
-                    ),
-                    start = string.indexOf(clickableText),
-                    end = string.indexOf(clickableText) + clickableText.length
-                )
-            },
-            status = notificationStatus,
-            highContrast = highContrast,
-            modifier = Modifier.width(IntrinsicSize.Max)
-        )
-    }
-
     var title by remember {
         mutableStateOf("Lorem ipsum")
     }
@@ -85,17 +51,7 @@ fun NotificationDemoScreen(modifier: Modifier = Modifier) {
         mutableStateOf("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
     }
 
-    val editableDemoNotification: @Composable ColumnScope.() -> Unit = {
-        CalloutNotification(
-            title = title,
-            body = body,
-            status = notificationStatus,
-            highContrast = highContrast,
-            modifier = Modifier.width(IntrinsicSize.Max)
-        )
-    }
-
-    val parametersContent: @Composable ColumnScope.() -> Unit = {
+    val parametersContent: @Composable ColumnScope.(TabItem) -> Unit = {
         TextInput(
             label = "Title",
             value = title,
@@ -126,13 +82,15 @@ fun NotificationDemoScreen(modifier: Modifier = Modifier) {
     }
 
     DemoScreen(
+        variants = variants,
         modifier = modifier,
         demoContent = {
-            urlDemoNotification()
-
-            Spacer(modifier = Modifier.height(SpacingScale.spacing05))
-
-            editableDemoNotification()
+            CalloutNotificationDemo(
+                title = title,
+                body = body,
+                notificationStatus = notificationStatus,
+                highContrast = highContrast
+            )
         },
         demoParametersContent = parametersContent,
         displayVariantsWIPNotification = true

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -33,6 +33,7 @@
     - [Small loading](https://gabrieldrn.github.io/carbon-compose/api/-carbon%20-compose/com.gabrieldrn.carbon.loading/-small-loading.html)
 - Notification
     - [Callout notification](https://gabrieldrn.github.io/carbon-compose/api/-carbon%20-compose/com.gabrieldrn.carbon.notification/-callout-notification.html)
+    - [Inline notification](https://gabrieldrn.github.io/carbon-compose/api/-carbon%20-compose/com.gabrieldrn.carbon.notification/-inline-notification.html)
 - Progress bar
     - [Default progress bar](https://gabrieldrn.github.io/carbon-compose/api/-carbon%20-compose/com.gabrieldrn.carbon.progressbar/-progress-bar.html)
     - [Indeterminate progress bar](https://gabrieldrn.github.io/carbon-compose/api/-carbon%20-compose/com.gabrieldrn.carbon.progressbar/-indeterminate-progress-bar.html)


### PR DESCRIPTION
<!-- 

  /!\ Important

  For changes on Carbon components, ensure the following:
  - Every component **variant** you have newly implemented/modified...:
    - Answers **all** specifications from official Carbon documentation website in terms of:
      - Theming: Colors with themes and layers.
      - Interactions: By mouse, keyboard and touch inputs.
      - Accessibility (guidelines & interactions).
      - Etc.
    - Is Unit & UI tested.
    - Is presented in a demo screen in the `:catalog` app module.
  - The API signature is updated (run `./gradlew apiDump`)
  - Public declarations are documented with KDoc blocs.
  - You have addressed all static code analysis issues (Detekt: run `./gradlew detekt`).
  - The documentation (MK docs + Dokka) is updated.

-->

<!--

  /!\ Important

  When creating your pull request, don't forget to link the related issue from the project's board:
    => https://github.com/users/gabrieldrn/projects/3
  You can add this link with the options on the right panel.

-->

# Notes / Description

- Implementation of inline notification variant
- Change common notification layout to allow for a "natural" min height of 48dp as required notification dimensions given on Carbon documentation doesn't mathematically compute.
- Introduce common methods `forEachParameter` for faster parameterization mainly on Compose UI tests.
- Remove useless baseline shift on `bodyCompact01` text style.
- Add capability of using inverse colors for global + button focus indication.

# Platforms testing checklist

<!-- 
  Ensure you have tested your changes with all the platforms available to you.
  Check the platforms you have tested onto in the list below. For the platforms you couldn't test, 
  add the mention "(needs test)" next to them. Project maintainers will run tests on all platforms to validate
  your changes anyway but it will make them pay extra attention on those platforms specifically.
-->

- [x] Android
- [x] iOS
- [x] Desktop
  - [ ] Linux
  - [x] Apple
  - [ ] Windows
- [x] WASM

# Screenshots / videos

<!-- Add a few media to present your changes -->
