### PR TITLE
Fix IndexOutOfBoundsException when opening a dropdown popup when selected option doesn't exist in given options.

### DIFF
--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/dropdown/base/DropdownPopupContent.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/dropdown/base/DropdownPopupContent.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
 import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.foundation.interaction.FocusIndication
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
@@ -95,9 +96,23 @@ internal fun <K : Any> DropdownPopupContent(
         }
     }
 
+    val initialFirstVisibleItemIndex = remember(options, selectedOptionIndex) {
+        options
+            .keys
+            .indexOf(compositionEndTargetOption)
+            .let {
+                if (it < 0) {
+                    Logger.w("Selected option not found in options")
+                    0
+                } else {
+                    it
+                }
+            }
+    }
+
     LazyColumn(
         state = rememberLazyListState(
-            initialFirstVisibleItemIndex = options.keys.indexOf(compositionEndTargetOption)
+            initialFirstVisibleItemIndex = initialFirstVisibleItemIndex
         ),
         modifier = modifier
             .background(color = colors.menuOptionBackgroundColor)


### PR DESCRIPTION
<!-- 

  /!\ Important

  For changes on Carbon components, ensure the following:
  - Every component **variant** you have newly implemented/modified...:
    - Answers **all** specifications from official Carbon documentation website in terms of:
      - Theming: Colors with themes and layers.
      - Interactions: By mouse, keyboard and touch inputs.
      - Accessibility (guidelines & interactions).
      - Etc.
    - Is Unit & UI tested.
    - Is presented in a demo screen in the `:catalog` app module.
  - The API signature is updated (run `./gradlew apiDump`)
  - Public declarations are documented with KDoc blocs.
  - You have addressed all static code analysis issues (Detekt: run `./gradlew detekt`).
  - The documentation (MK docs + Dokka) is updated.

-->

<!--

  /!\ Important

  When creating your pull request, don't forget to link the related issue from the project's board:
    => https://github.com/users/gabrieldrn/projects/3
  You can add this link with the options on the right panel.

-->

# Notes / Description

Resolves crash reported in #84

# Platforms testing checklist

<!-- 
  Ensure you have tested your changes with all the platforms available to you.
  Check the platforms you have tested onto in the list below. For the platforms you couldn't test, 
  add the mention "(needs test)" next to them. Project maintainers will run tests on all platforms to validate
  your changes anyway but it will make them pay extra attention on those platforms specifically.
-->

- [x] Android
- [x] iOS
- [x] Desktop
  - [x] Linux
  - [x] Apple
  - [ ] Windows
- [x] WASM
