### PR TITLE
fix(dropdown): align warning/error helper text to the right in inline variant

### DIFF
--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/dropdown/base/BaseDropdown.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/dropdown/base/BaseDropdown.kt
@@ -166,29 +166,57 @@ internal fun <K : Any> BaseDropdown(
     }
 
     if (isInlined) {
-        Row(
-            modifier = modifier,
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            label.takeIf { !it.isNullOrBlank() }?.let {
-                DropdownLabel(
-                    text = it,
-                    color = labelTextColor
-                )
-            }
-
-            Column(modifier = Modifier.padding(start = SpacingScale.spacing06)) {
-                fieldAndPopup()
+        val isWarningOrError = state is DropdownInteractiveState.Warning
+            || state is DropdownInteractiveState.Error
+        if (isWarningOrError) {
+            Row(
+                modifier = modifier,
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpacingScale.spacing06)
+            ) {
+                label.takeIf { !it.isNullOrBlank() }?.let {
+                    DropdownLabel(
+                        text = it,
+                        color = labelTextColor
+                    )
+                }
 
                 state.helperText?.let {
                     DropdownHelperText(
                         text = it,
-                        color = helperTextColor
+                        color = helperTextColor,
+                        modifier = Modifier
+                            .padding(start = SpacingScale.spacing06)
+                            .align(Alignment.CenterVertically)
                     )
                 }
             }
+        } else {
+            Row(
+                modifier = modifier,
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                label.takeIf { !it.isNullOrBlank() }?.let {
+                    DropdownLabel(
+                        text = it,
+                        color = labelTextColor
+                    )
+                }
+
+                Column(modifier = Modifier.padding(start = SpacingScale.spacing06)) {
+                    fieldAndPopup()
+
+                    state.helperText?.let {
+                        DropdownHelperText(
+                            text = it,
+                            color = helperTextColor
+                        )
+                    }
+                }
+            }
         }
+
     } else {
         Column(modifier = modifier) {
             label.takeIf { !it.isNullOrBlank() }?.let {


### PR DESCRIPTION
Fixes #71 – Warning and Error messages in the inline dropdown now render to the right of the field per Carbon spec.
https://github.com/gabrieldrn/carbon-compose/issues/71

- [ ] Android needs test
- [ ] iOSneeds test
- [ x ] Desktop
  - [ ] Linux needs test
  - [ ] Apple needs test
  - [ ] Windows needs test
- [ ] WASM needs test

# Screenshots / videos
<img width="863" alt="Screenshot 2025-05-04 at 2 48 38 PM" src="https://github.com/user-attachments/assets/20079cbe-0326-46ed-a722-6cf305f435fa" />

