### PR TITLE
Add size support for icon buttons

### DIFF
--- a/carbon/api/android/carbon.api
+++ b/carbon/api/android/carbon.api
@@ -104,8 +104,8 @@ public final class com/gabrieldrn/carbon/button/ButtonType : java/lang/Enum {
 }
 
 public final class com/gabrieldrn/carbon/button/IconButtonKt {
-	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lcom/gabrieldrn/carbon/tooltip/TooltipParameters;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
-	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lcom/gabrieldrn/carbon/tooltip/TooltipParameters;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;Lcom/gabrieldrn/carbon/button/ButtonSize;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;Lcom/gabrieldrn/carbon/button/ButtonSize;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gabrieldrn/carbon/checkbox/CheckboxKt {

--- a/carbon/api/desktop/carbon.api
+++ b/carbon/api/desktop/carbon.api
@@ -104,8 +104,8 @@ public final class com/gabrieldrn/carbon/button/ButtonType : java/lang/Enum {
 }
 
 public final class com/gabrieldrn/carbon/button/IconButtonKt {
-	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lcom/gabrieldrn/carbon/tooltip/TooltipParameters;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
-	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lcom/gabrieldrn/carbon/tooltip/TooltipParameters;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;Lcom/gabrieldrn/carbon/button/ButtonSize;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IconButton (Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lcom/gabrieldrn/carbon/button/ButtonType;Lcom/gabrieldrn/carbon/button/ButtonSize;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/gabrieldrn/carbon/checkbox/CheckboxKt {

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/ButtonImpl.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/ButtonImpl.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -56,20 +57,24 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.foundation.motion.Motion
-import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
 
 internal val buttonTransitionSpec = tween<Float>(
     durationMillis = Motion.Duration.fast01,
     easing = Motion.Entrance.productiveEasing
 )
 
-private fun Modifier.requiredButtonSize(buttonSize: ButtonSize, isIconButton: Boolean) =
-    this
-        .requiredSize(
-            width = if (isIconButton) SpacingScale.spacing09 else Dp.Unspecified,
-            height = if (isIconButton) SpacingScale.spacing09 else buttonSize.heightDp()
-        )
-        .width(IntrinsicSize.Max)
+private fun Modifier.requiredButtonSize(buttonSize: ButtonSize, isIconButton: Boolean): Modifier =
+    this then if (isIconButton) {
+        Modifier.size(buttonSize.heightDp())
+    } else {
+        Modifier
+            .requiredSize(
+                width = Dp.Unspecified,
+                height = buttonSize.heightDp()
+            )
+            .width(IntrinsicSize.Max)
+    }
+
 
 private fun AnimatedContentTransitionScope<ButtonScope>.getContentTransition() =
     if (initialState.isEnabled != targetState.isEnabled) {

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/IconButton.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/IconButton.kt
@@ -43,6 +43,7 @@ import com.gabrieldrn.carbon.tooltip.TooltipParameters
  * @param onClick Callback invoked when the button is clicked.
  * @param modifier The modifier to be applied to the button.
  * @param buttonType A [ButtonType] that defines the button's type.
+ * @param buttonSize A [ButtonSize] that defines the button's size.
  * @param isEnabled Whether the button is enabled or disabled.
  * @param interactionSource The [MutableInteractionSource] that keeps track of the button's state.
  *
@@ -54,13 +55,14 @@ public fun IconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     buttonType: ButtonType = ButtonType.Primary,
+    buttonSize: ButtonSize = ButtonSize.LargeProductive,
     isEnabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     ButtonRowImpl(
         onClick = onClick,
         buttonType = buttonType,
-        buttonSize = ButtonSize.LargeProductive,
+        buttonSize = buttonSize,
         isEnabled = isEnabled,
         modifier = modifier,
         isIconButton = true,
@@ -70,7 +72,14 @@ public fun IconButton(
             painter = iconPainter,
             scope = buttonScope,
             modifier = Modifier
-                .padding(start = SpacingScale.spacing05, top = SpacingScale.spacing05)
+                .weight(1f)
+                .padding(
+                    top = when (buttonSize) {
+                        ButtonSize.Small -> SpacingScale.spacing03
+                        ButtonSize.Medium -> SpacingScale.spacing04
+                        else -> SpacingScale.spacing05
+                    }
+                )
                 .size(SpacingScale.spacing05)
         )
     }
@@ -96,6 +105,7 @@ public fun IconButton(
  * @param modifier The modifier to be applied to the button.
  * @param tooltipModifier The modifier to be applied to the tooltip.
  * @param buttonType A [ButtonType] that defines the button's type.
+ * @param buttonSize A [ButtonSize] that defines the button's size.
  * @param isEnabled Whether the button is enabled or disabled.
  * @param interactionSource The [MutableInteractionSource] that keeps track of the button's state.
  *
@@ -110,6 +120,7 @@ public fun IconButton(
     modifier: Modifier = Modifier,
     tooltipModifier: Modifier = Modifier,
     buttonType: ButtonType = ButtonType.Primary,
+    buttonSize: ButtonSize = ButtonSize.LargeProductive,
     isEnabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
@@ -123,6 +134,7 @@ public fun IconButton(
             onClick = onClick,
             modifier = modifier,
             buttonType = buttonType,
+            buttonSize = buttonSize,
             isEnabled = isEnabled,
             interactionSource = interactionSource
         )

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/button/IconButtonTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/button/IconButtonTest.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.isFocusable
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.icons.closeIcon
 import kotlin.test.Test
 
@@ -42,9 +41,12 @@ class IconButtonTest {
 
     @Test
     fun iconButton_validateLayout() = runComposeUiTest {
+        var buttonSize by mutableStateOf(ButtonSize.Small)
+
         setContent {
             IconButton(
                 iconPainter = rememberVectorPainter(closeIcon),
+                buttonSize = buttonSize,
                 onClick = {},
                 modifier = Modifier.testTag("IconButton")
             )
@@ -52,8 +54,15 @@ class IconButtonTest {
 
         onNodeWithTag("IconButton")
             .assertExists()
-            .assertWidthIsEqualTo(48.dp)
-            .assertHeightIsEqualTo(48.dp)
+
+        ButtonSize.entries.forEach { size ->
+            buttonSize = size
+
+            val dpSize = size.heightDp()
+            onNodeWithTag("IconButton")
+                .assertWidthIsEqualTo(dpSize)
+                .assertHeightIsEqualTo(dpSize)
+        }
     }
 
     @Test

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/buttons/ButtonsDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/buttons/ButtonsDemoScreen.kt
@@ -99,6 +99,7 @@ fun ButtonDemoScreen(modifier: Modifier = Modifier) {
                     iconPainter = icon,
                     isEnabled = isEnabled,
                     buttonType = buttonType,
+                    buttonSize = buttonSize
                 )
             }
         }


### PR DESCRIPTION
<!-- 

  /!\ Important

  For changes on Carbon components, ensure the following:
  - Every component **variant** you have newly implemented/modified...:
    - Answers **all** specifications from official Carbon documentation website in terms of:
      - Theming: Colors with themes and layers.
      - Interactions: By mouse, keyboard and touch inputs.
      - Accessibility (guidelines & interactions).
      - Etc.
    - Is Unit & UI tested.
    - Is presented in a demo screen in the `:catalog` app module.
  - The API signature is updated (run `./gradlew apiDump`)
  - Public declarations are documented with KDoc blocs.
  - You have addressed all static code analysis issues (Detekt: run `./gradlew detekt`).
  - The documentation (MK docs + Dokka) is updated.

-->

<!--

  /!\ Important

  When creating your pull request, don't forget to link the related issue from the project's board:
    => https://github.com/users/gabrieldrn/projects/3
  You can add this link with the options on the right panel.

-->

# Notes / Description

Adds support for icon button size change by adding it an argument accepting a `ButtonSize`.

# Platforms testing checklist

<!-- 
  Ensure you have tested your changes with all the platforms available to you.
  Check the platforms you have tested onto in the list below. For the platforms you couldn't test, 
  add the mention "(needs test)" next to them. Project maintainers will run tests on all platforms to validate
  your changes anyway but it will make them pay extra attention on those platforms specifically.
-->

- [x] Android
- [x] iOS
- [x] Desktop
  - [ ] Linux
  - [x] Apple
  - [ ] Windows
- [x] WASM

# Screenshots / videos

<!-- Add a few media to present your changes -->
