### PR TITLE
Visual press indication on buttons is partially working for mobile targets

### DIFF
--- a/carbon/src/androidMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.android.kt
+++ b/carbon/src/androidMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.android.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.button
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.filterIsInstance
+
+@Composable
+internal actual fun rememberIsButtonPressed(
+    interactionSource: InteractionSource,
+    containerColorAnimatable: Animatable<*, *>,
+    buttonColors: ButtonColors
+): State<Boolean> {
+    val containerColorState by containerColorAnimatable.asState()
+    val isPressed = remember { mutableStateOf(false) }
+    var isReleasedOrCancelled by remember { mutableStateOf(false) }
+
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions
+            .filterIsInstance<PressInteraction>()
+            .collect {
+                if (it is PressInteraction.Press) {
+                    isReleasedOrCancelled = false
+                    isPressed.value = true
+                } else {
+                    isReleasedOrCancelled = true
+                }
+            }
+    }
+
+    LaunchedEffect(containerColorState, isReleasedOrCancelled) {
+        if (containerColorState == buttonColors.containerActiveColor && isReleasedOrCancelled) {
+            isPressed.value = false
+        }
+    }
+
+    return isPressed
+}

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.button
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+
+/**
+ * When using `interactionSource.collectIsPressedAsState()` for mobile targets, the animation seems
+ * to be delayed and a simple tap on the button immediately cancels it, resulting in no visual
+ * feedback.
+ * This issue does not occur on desktop and wasm targets, so this function is directly
+ * reusing `interactionSource.collectIsPressedAsState()`. However, for the mobile targets, a custom
+ * implementation is provided as a temp workaround, where the state is updated only when the color
+ * animation completes.
+ */
+@Composable
+internal expect fun rememberIsButtonPressed(
+    interactionSource: InteractionSource,
+    containerColorAnimatable: Animatable<*, *>,
+    buttonColors: ButtonColors
+): State<Boolean>

--- a/carbon/src/desktopMain/java/com/gabrieldrn/carbon/button/ButtonPressInteraction.desktop.kt
+++ b/carbon/src/desktopMain/java/com/gabrieldrn/carbon/button/ButtonPressInteraction.desktop.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.button
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.State
+
+@androidx.compose.runtime.Composable
+internal actual fun rememberIsButtonPressed(
+    interactionSource: InteractionSource,
+    containerColorAnimatable: Animatable<*, *>,
+    buttonColors: ButtonColors
+): State<Boolean> =
+    interactionSource.collectIsPressedAsState()

--- a/carbon/src/nativeMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.native.kt
+++ b/carbon/src/nativeMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.native.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.button
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.filterIsInstance
+
+@Composable
+internal actual fun rememberIsButtonPressed(
+    interactionSource: InteractionSource,
+    containerColorAnimatable: Animatable<*, *>,
+    buttonColors: ButtonColors
+): State<Boolean> {
+    val containerColorState by containerColorAnimatable.asState()
+    val isPressed = remember { mutableStateOf(false) }
+    var isReleasedOrCancelled by remember { mutableStateOf(false) }
+
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions
+            .filterIsInstance<PressInteraction>()
+            .collect {
+                if (it is PressInteraction.Press) {
+                    isReleasedOrCancelled = false
+                    isPressed.value = true
+                } else {
+                    isReleasedOrCancelled = true
+                }
+            }
+    }
+
+    LaunchedEffect(containerColorState, isReleasedOrCancelled) {
+        if (containerColorState == buttonColors.containerActiveColor && isReleasedOrCancelled) {
+            isPressed.value = false
+        }
+    }
+
+    return isPressed
+}

--- a/carbon/src/wasmJsMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.wasmJs.kt
+++ b/carbon/src/wasmJsMain/kotlin/com/gabrieldrn/carbon/button/ButtonPressInteraction.wasmJs.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.button
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+
+@Composable
+internal actual fun rememberIsButtonPressed(
+    interactionSource: InteractionSource,
+    containerColorAnimatable: Animatable<*, *>,
+    buttonColors: ButtonColors
+): State<Boolean> =
+    interactionSource.collectIsPressedAsState()


### PR DESCRIPTION
<!-- 

  /!\ Important

  For changes on Carbon components, ensure the following:
  - Every component **variant** you have newly implemented/modified...:
    - Answers **all** specifications from official Carbon documentation website in terms of:
      - Theming: Colors with themes and layers.
      - Interactions: By mouse, keyboard and touch inputs.
      - Accessibility (guidelines & interactions).
      - Etc.
    - Is Unit & UI tested.
    - Is presented in a demo screen in the `:catalog` app module.
  - The API signature is updated (run `./gradlew apiDump`)
  - Public declarations are documented with KDoc blocs.
  - You have addressed all static code analysis issues (Detekt: run `./gradlew detekt`).
  - The documentation (MK docs + Dokka) is updated.

-->

<!--

  /!\ Important

  When creating your pull request, don't forget to link the related issue from the project's board:
    => https://github.com/users/gabrieldrn/projects/3
  You can add this link with the options on the right panel.

-->

# Notes / Description

This pull request introduces a platform-specific implementation of the button press interactions to address an animation issue on mobile platforms. It also includes refactoring and enhancements for button animations and transitions.

The main issue is that on mobile platform, when performing a single tap on a button, the press indication is not displayed. When doing a longer press, the animation starts but gets immediately canceled when released quickly.

The implemented solution will wait for the running press animation to end before animating back until all press interactions are released. 

# Platforms testing checklist

<!-- 
  Ensure you have tested your changes with all the platforms available to you.
  Check the platforms you have tested onto in the list below. For the platforms you couldn't test, 
  add the mention "(needs test)" next to them. Project maintainers will run tests on all platforms to validate
  your changes anyway but it will make them pay extra attention on those platforms specifically.
-->

- [x] Android
- [x] iOS
- [x] Desktop
  - [ ] Linux
  - [x] Apple
  - [ ] Windows
- [x] WASM

# Screenshots / videos

<!-- Add a few media to present your changes -->
