### PR TITLE
Disable single line restriction on text inputs label 

### DIFF
--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/textinput/TextArea.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/textinput/TextArea.kt
@@ -135,7 +135,6 @@ public fun TextArea(
     )
 }
 
-
 @Preview
 @Composable
 private fun EmptyTextAreaPreview(

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/textinput/TextInput.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/textinput/TextInput.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -201,30 +202,34 @@ internal fun decorator(
     counter: Pair<Int, Int>?,
     trailingIcon: @Composable (() -> Unit)?
 ): @Composable (@Composable () -> Unit) -> Unit = { innerTextField ->
+    val labelColor by colors.labelTextColor(state = state)
+    val counterColor by colors.labelTextColor(state = state)
+    val helperColor by colors.helperTextColor(state = state)
+
     Column(
         modifier = Modifier.semantics(mergeDescendants = true) {
             stateDescription = helperText
         }
     ) {
         Row(
-            modifier = Modifier
-                .padding(bottom = SpacingScale.spacing03)
+            modifier = Modifier.padding(bottom = SpacingScale.spacing03),
+            verticalAlignment = Alignment.Bottom
         ) {
-            Text(
+            BasicText(
                 text = label,
                 style = Carbon.typography.label01,
-                color = colors.labelTextColor(state = state).value,
-                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = { labelColor },
                 modifier = Modifier
                     .weight(1f)
                     .testTag(TextInputTestTags.LABEL)
             )
 
             if (counter != null) {
-                Text(
+                BasicText(
                     text = "${counter.first}/${counter.second}",
                     style = Carbon.typography.label01,
-                    color = colors.labelTextColor(state = state).value,
+                    color = { counterColor },
                     maxLines = 1,
                     modifier = Modifier.testTag(TextInputTestTags.COUNTER)
                 )
@@ -261,10 +266,10 @@ internal fun decorator(
         )
 
         if (helperText.isNotEmpty()) {
-            Text(
+            BasicText(
                 text = helperText,
                 style = Carbon.typography.helperText01,
-                color = colors.helperTextColor(state = state).value,
+                color = { helperColor },
                 modifier = Modifier
                     .padding(top = SpacingScale.spacing02)
                     .testTag(TextInputTestTags.HELPER_TEXT)
@@ -356,8 +361,7 @@ internal class TextInputStatePreviewParameterProvider : PreviewParameterProvider
 
 @Preview
 @Composable
-private fun EmptyTextInputPreview(
-) {
+private fun EmptyTextInputPreview() {
     var text by remember {
         mutableStateOf("")
     }

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/textinput/TextInputDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/textinput/TextInputDemoScreen.kt
@@ -44,6 +44,7 @@ import com.gabrieldrn.carbon.textinput.PasswordInput
 import com.gabrieldrn.carbon.textinput.TextArea
 import com.gabrieldrn.carbon.textinput.TextInput
 import com.gabrieldrn.carbon.textinput.TextInputState
+import com.gabrieldrn.carbon.toggle.Toggle
 import org.jetbrains.compose.resources.painterResource
 
 private val textInputStateOptions = TextInputState.entries.toDropdownOptions()
@@ -65,6 +66,7 @@ fun TextInputDemoScreen(modifier: Modifier = Modifier) {
     var textInputState by rememberSaveable { mutableStateOf(TextInputState.Enabled) }
     var text by rememberSaveable { mutableStateOf("") }
     var passwordHidden by rememberSaveable { mutableStateOf(true) }
+    var useCounter by rememberSaveable { mutableStateOf(false) }
 
     val focusRequester = remember { FocusRequester() }
 
@@ -90,8 +92,28 @@ fun TextInputDemoScreen(modifier: Modifier = Modifier) {
                     state = textInputState,
                     modifier = Modifier.focusRequester(focusRequester)
                 )
-                TextInputVariant.TextArea -> TextArea(
-                    label = "Text area",
+                TextInputVariant.TextArea if useCounter -> {
+                    val limit = 1000
+                    val counter by remember(text) {
+                        mutableStateOf(text.count() to limit)
+                    }
+
+                    TextArea(
+                        label = "Text area ",
+                        value = text,
+                        onValueChange = {
+                            if (it.count() <= limit) { text = it }
+                        },
+                        placeholderText = "Placeholder",
+                        helperText = textInputState.name,
+                        state = textInputState,
+                        maxLines = 5,
+                        counter = counter,
+                        modifier = Modifier.focusRequester(focusRequester)
+                    )
+                }
+                TextInputVariant.TextArea if !useCounter -> TextArea(
+                    label = "Text area ",
                     value = text,
                     onValueChange = { text = it },
                     placeholderText = "Placeholder",
@@ -137,9 +159,17 @@ fun TextInputDemoScreen(modifier: Modifier = Modifier) {
                 )
             }
 
+            Toggle(
+                isToggled = useCounter,
+                onToggleChange = { useCounter = it },
+                label = "Use character counter",
+                isEnabled = variant == TextInputVariant.TextArea
+            )
+
             Button(
                 label = "Request focus",
-                onClick = { focusRequester.requestFocus() }
+                onClick = { focusRequester.requestFocus() },
+                modifier = Modifier.padding(top = SpacingScale.spacing03)
             )
         },
         modifier = modifier


### PR DESCRIPTION
<!-- 

  /!\ Important

  For changes on Carbon components, ensure the following:
  - Every component **variant** you have newly implemented/modified...:
    - Answers **all** specifications from official Carbon documentation website in terms of:
      - Theming: Colors with themes and layers.
      - Interactions: By mouse, keyboard and touch inputs.
      - Accessibility (guidelines & interactions).
      - Etc.
    - Is Unit & UI tested.
    - Is presented in a demo screen in the `:catalog` app module.
  - The API signature is updated (run `./gradlew apiDump`)
  - Public declarations are documented with KDoc blocs.
  - You have addressed all static code analysis issues (Detekt: run `./gradlew detekt`).
  - The documentation (MK docs + Dokka) is updated.

-->

<!--

  /!\ Important

  When creating your pull request, don't forget to link the related issue from the project's board:
    => https://github.com/users/gabrieldrn/projects/3
  You can add this link with the options on the right panel.

-->

# Notes / Description

Removes the 1-line max restriction on text inputs label, adjusts the label + counter accordingly, update text area demo to demonstrate a counter.

Resolves #114

# Platforms testing checklist

<!-- 
  Ensure you have tested your changes with all the platforms available to you.
  Check the platforms you have tested onto in the list below. For the platforms you couldn't test, 
  add the mention "(needs test)" next to them. Project maintainers will run tests on all platforms to validate
  your changes anyway but it will make them pay extra attention on those platforms specifically.
-->

- [x] Android
- [x] iOS
- [ ] Desktop
  - [ ] Linux
  - [x] Apple
  - [ ] Windows
- [x] WASM

# Screenshots / videos

<!-- Add a few media to present your changes -->
