### PR TITLE
Fix missing warning and error icons in CalendarDatePicker #120

### DIFF
--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/textinput/InputDecorator.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/textinput/InputDecorator.kt
@@ -135,6 +135,7 @@ internal fun inputDecorator(
             }
         }
 
+
         if (helperText.isNotEmpty()) {
             BasicText(
                 text = helperText,
@@ -156,8 +157,7 @@ internal fun Modifier.fieldBackground(
     val borderColor by colors.fieldBorderColor(state = state)
     drawBehind {
         drawRect(backgroundColor)
-        drawRect(borderColor, topLeft = Offset.Zero.copy(y = size.height - 1.dp.toPx())
-        )
+        drawRect(borderColor, topLeft = Offset.Zero.copy(y = size.height - 1.dp.toPx()))
     }
 }
 


### PR DESCRIPTION
<!-- 

  /!\ Important

  This change fixes a visual regression in an existing Carbon component.
  No new component variants or APIs are introduced.

-->

<!--

  /!\ Important

  Related issue is linked below.

https://github.com/gabrieldrn/carbon-compose/issues/120

-->

# Notes / Description

CalendarDatePicker was overriding the `stateIcon` parameter when using
`inputDecorator`, which prevented the default warning and error status
icons from being displayed.

This change removes the override so that the default state icons are
rendered correctly for `TextInputState.Warning` and `TextInputState.Error`,
while keeping the calendar trailing icon unchanged.

No API changes were required.

# Platforms testing checklist

- [x] Android
- [ ] iOS (needs test)
- [ ] Desktop
  - [ ] Linux (needs test)
  - [ ] Apple (needs test)
  - [ ] Windows (needs test)
- [ ] WASM (needs test)

# Screenshots / videos
<img width="1080" height="2220" alt="Screenshot_20260124_003333" src="https://github.com/user-attachments/assets/03fe618b-1da1-46d1-aded-547790ba28cf" />
<img width="1080" height="2220" alt="Screenshot_20260124_003349" src="https://github.com/user-attachments/assets/97625a4d-f891-44b1-99c1-d6063cdb1b33" />

<!--
Before:
- Warning and Error states did not display a status icon.

After:
- Warning and Error states correctly display the default Carbon status icons.
-->
