### PR TITLE
Implement date input component

### DIFF
--- a/carbon/api/desktop/carbon.api
+++ b/carbon/api/desktop/carbon.api
@@ -224,8 +224,30 @@ public final class com/gabrieldrn/carbon/datepicker/ComposableSingletons$Calenda
 	public final fun getLambda$1047216223$carbon ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/gabrieldrn/carbon/datepicker/ComposableSingletons$SimpleDateInputKt {
+	public static final field INSTANCE Lcom/gabrieldrn/carbon/datepicker/ComposableSingletons$SimpleDateInputKt;
+	public fun <init> ()V
+	public final fun getLambda$-1467816081$carbon ()Lkotlin/jvm/functions/Function2;
+}
+
 public abstract interface class com/gabrieldrn/carbon/datepicker/SelectableDates {
 	public abstract fun isSelectable (Lkotlinx/datetime/LocalDate;)Z
+}
+
+public final class com/gabrieldrn/carbon/datepicker/SimpleDateInputKt {
+	public static final fun SimpleDateInput (Lcom/gabrieldrn/carbon/datepicker/SimpleDateInputState;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Lcom/gabrieldrn/carbon/textinput/TextInputState;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;III)V
+}
+
+public abstract interface class com/gabrieldrn/carbon/datepicker/SimpleDateInputState {
+	public abstract fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public abstract fun getUpdateFieldCallback ()Lkotlin/jvm/functions/Function1;
+	public abstract fun setSelectedDate (Lkotlinx/datetime/LocalDate;)V
+	public abstract fun setUpdateFieldCallback (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun updateFieldValue (Ljava/lang/String;)V
+}
+
+public final class com/gabrieldrn/carbon/datepicker/SimpleDateInputStateKt {
+	public static final fun rememberSimpleDateInputState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/format/DateTimeFormat;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/gabrieldrn/carbon/datepicker/SimpleDateInputState;
 }
 
 public final class com/gabrieldrn/carbon/dropdown/DropdownKt {

--- a/carbon/api/desktop/carbon.api
+++ b/carbon/api/desktop/carbon.api
@@ -239,15 +239,16 @@ public final class com/gabrieldrn/carbon/datepicker/SimpleDateInputKt {
 }
 
 public abstract interface class com/gabrieldrn/carbon/datepicker/SimpleDateInputState {
-	public abstract fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public abstract fun getSelectedDate ()Ljava/lang/Object;
 	public abstract fun getUpdateFieldCallback ()Lkotlin/jvm/functions/Function1;
-	public abstract fun setSelectedDate (Lkotlinx/datetime/LocalDate;)V
+	public abstract fun setSelectedDate (Ljava/lang/Object;)V
 	public abstract fun setUpdateFieldCallback (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun updateFieldValue (Ljava/lang/String;)V
 }
 
 public final class com/gabrieldrn/carbon/datepicker/SimpleDateInputStateKt {
-	public static final fun rememberSimpleDateInputState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/format/DateTimeFormat;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/gabrieldrn/carbon/datepicker/SimpleDateInputState;
+	public static final fun rememberApproximateSimpleDateInputState (Lkotlinx/datetime/YearMonth;Lkotlinx/datetime/format/DateTimeFormat;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/gabrieldrn/carbon/datepicker/SimpleDateInputState;
+	public static final fun rememberMemorableSimpleDateInputState (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/format/DateTimeFormat;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/gabrieldrn/carbon/datepicker/SimpleDateInputState;
 }
 
 public final class com/gabrieldrn/carbon/dropdown/DropdownKt {

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
@@ -39,7 +39,6 @@ import com.gabrieldrn.carbon.textinput.TextInputColors
 import com.gabrieldrn.carbon.textinput.TextInputState
 import com.gabrieldrn.carbon.textinput.inputDecorator
 
-// TODO Tests
 /**
  * # Date picker - Simple
  *

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
@@ -39,6 +39,47 @@ import com.gabrieldrn.carbon.textinput.TextInputColors
 import com.gabrieldrn.carbon.textinput.TextInputState
 import com.gabrieldrn.carbon.textinput.inputDecorator
 
+// TODO Tests
+/**
+ * # Date picker - Simple
+ *
+ * Simple date inputs allow users to type a specific date directly into a text field. Unlike the
+ * calendar date picker, this variant has no calendar menu popup. The placeholder text should
+ * indicate the expected date format to guide the user.
+ *
+ * ## Compose implementation
+ * The component delegates date parsing and formatting to [SimpleDateInputState], which can be
+ * created with [rememberSimpleDateInputState]. Use the [inputState] parameter to reflect
+ * validation results (e.g. [com.gabrieldrn.carbon.textinput.TextInputState.Error]) after
+ * checking the validity callback passed to [rememberSimpleDateInputState].
+ *
+ * (From [Date picker documentation](https://carbondesignsystem.com/components/date-picker/usage/#simple-date-input))
+ *
+ * @param state A [SimpleDateInputState] that controls this component, holding the currently
+ * selected date and the logic to parse typed input.
+ * @param label Text that informs the user about the content they need to type in the field.
+ * @param value The input [String] text to be shown in the text field.
+ * @param onValueChange Callback triggered when the input service updates the text. The updated
+ * text is passed as a parameter.
+ * @param modifier Optional [Modifier] for this component.
+ * @param placeholderText Optional hint text displayed when the field is empty, typically used to
+ * convey the expected date format (e.g. `"mm/dd/yyyy"`).
+ * @param helperText Optional helper text displayed below the field to assist the user in entering
+ * the correct date format.
+ * @param inputState The interactive state of the text field, such as
+ * [com.gabrieldrn.carbon.textinput.TextInputState.Enabled],
+ * [com.gabrieldrn.carbon.textinput.TextInputState.Error], or
+ * [com.gabrieldrn.carbon.textinput.TextInputState.Disabled].
+ * @param keyboardOptions Software keyboard options that contain configuration such as
+ * [androidx.compose.ui.text.input.KeyboardType] and [androidx.compose.ui.text.input.ImeAction].
+ * @param keyboardActions When the input service emits an IME action, the corresponding callback
+ * is called. Note that this IME action may be different from what you specified in
+ * [KeyboardOptions.imeAction].
+ * @param interactionSource The [MutableInteractionSource] representing the stream of
+ * [androidx.compose.foundation.interaction.Interaction]s for this text field. You can create and
+ * pass in your own remembered [MutableInteractionSource] if you want to observe interactions and
+ * customize the appearance or behavior of this field in different interaction states.
+ */
 @Composable
 public fun SimpleDateInput(
     state: SimpleDateInputState,

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
@@ -137,7 +137,7 @@ public fun <T> SimpleDateInput(
         maxLines = 1,
         minLines = 1,
         interactionSource = interactionSource,
-        cursorBrush = SolidColor(colors.fieldTextColor(state = inputState).value),
+        cursorBrush = SolidColor(fieldTextColor),
         decorationBox = inputDecorator(
             label = label,
             value = value,

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.datepicker
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import com.gabrieldrn.carbon.Carbon
+import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.common.semantics.readOnly
+import com.gabrieldrn.carbon.textinput.TextInputColors
+import com.gabrieldrn.carbon.textinput.TextInputState
+import com.gabrieldrn.carbon.textinput.inputDecorator
+
+@Composable
+public fun SimpleDateInput(
+    state: SimpleDateInputState,
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholderText: String = "",
+    helperText: String = "",
+    inputState: TextInputState = TextInputState.Enabled,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    val theme = Carbon.theme
+    val typography = Carbon.typography
+    val colors = TextInputColors.colors()
+
+    state.updateFieldCallback = onValueChange
+
+    val fieldTextColor by colors.fieldTextColor(state = inputState)
+    val fieldTextStyle by remember(fieldTextColor) {
+        mutableStateOf(typography.bodyCompact01.copy(color = fieldTextColor))
+    }
+
+    BasicTextField(
+        value = value,
+        onValueChange = state::updateFieldValue,
+        modifier = modifier
+            .then(
+                when (inputState) {
+                    TextInputState.Disabled -> Modifier.semantics {
+                        role = Role.ValuePicker
+                        disabled()
+                    }
+                    TextInputState.ReadOnly -> Modifier.readOnly(
+                        role = Role.ValuePicker,
+                        interactionSource = interactionSource,
+                        mergeDescendants = true
+                    )
+                    else -> Modifier
+                }
+            ),
+        enabled = inputState != TextInputState.Disabled,
+        readOnly = inputState == TextInputState.ReadOnly,
+        textStyle = fieldTextStyle,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        singleLine = true,
+        maxLines = 1,
+        minLines = 1,
+        interactionSource = interactionSource,
+        cursorBrush = SolidColor(colors.fieldTextColor(state = inputState).value),
+        decorationBox = inputDecorator(
+            label = label,
+            value = value,
+            placeholderText = placeholderText,
+            helperText = helperText,
+            state = inputState,
+            theme = theme,
+            colors = colors,
+            singleLine = true,
+            interactionSource = interactionSource,
+            counter = null,
+            trailingIcon = null,
+        )
+    )
+}
+
+// region Previews
+
+@Preview
+@Composable
+private fun SimpleDateInputPreview() {
+    CarbonDesignSystem {
+        var value by remember { mutableStateOf("") }
+
+        SimpleDateInput(
+            state = rememberSimpleDateInputState(),
+            label = "Date input",
+            placeholderText = "mm/yyyy",
+            value = value,
+            onValueChange = { value = it }
+        )
+    }
+}
+
+// endregion

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInput.kt
@@ -47,13 +47,19 @@ import com.gabrieldrn.carbon.textinput.inputDecorator
  * indicate the expected date format to guide the user.
  *
  * ## Compose implementation
- * The component delegates date parsing and formatting to [SimpleDateInputState], which can be
- * created with [rememberSimpleDateInputState]. Use the [inputState] parameter to reflect
- * validation results (e.g. [com.gabrieldrn.carbon.textinput.TextInputState.Error]) after
- * checking the validity callback passed to [rememberSimpleDateInputState].
+ * The component delegates date parsing and formatting to a [SimpleDateInputState]. Carbon offers
+ * two implementations of this state:
+ * - [rememberMemorableSimpleDateInputState] for precise dates (day, month and year).
+ * - [rememberApproximateSimpleDateInputState] for approximate dates (month and year only).
+ * Use the [inputState] parameter to reflect validation results
+ * (e.g. [com.gabrieldrn.carbon.textinput.TextInputState.Error]) after checking the validity
+ * callback passed to the remember* function.
  *
  * (From [Date picker documentation](https://carbondesignsystem.com/components/date-picker/usage/#simple-date-input))
  *
+ * @param T Date data type, determined by [SimpleDateInputState]. Most common types usually come
+ * from `kotlinx.datetime`: [kotlinx.datetime.LocalDate] for "memorable" dates, and
+ * [kotlinx.datetime.YearMonth] for approximate ones.
  * @param state A [SimpleDateInputState] that controls this component, holding the currently
  * selected date and the logic to parse typed input.
  * @param label Text that informs the user about the content they need to type in the field.
@@ -80,8 +86,8 @@ import com.gabrieldrn.carbon.textinput.inputDecorator
  * customize the appearance or behavior of this field in different interaction states.
  */
 @Composable
-public fun SimpleDateInput(
-    state: SimpleDateInputState,
+public fun <T> SimpleDateInput(
+    state: SimpleDateInputState<T>,
     label: String,
     value: String,
     onValueChange: (String) -> Unit,
@@ -110,7 +116,7 @@ public fun SimpleDateInput(
         modifier = modifier
             .then(
                 when (inputState) {
-                    TextInputState.Disabled -> Modifier.semantics {
+                    TextInputState.Disabled -> Modifier.semantics(mergeDescendants = true) {
                         role = Role.ValuePicker
                         disabled()
                     }
@@ -157,7 +163,7 @@ private fun SimpleDateInputPreview() {
         var value by remember { mutableStateOf("") }
 
         SimpleDateInput(
-            state = rememberSimpleDateInputState(),
+            state = rememberMemorableSimpleDateInputState(),
             label = "Date input",
             placeholderText = "mm/yyyy",
             value = value,

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputState.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputState.kt
@@ -29,6 +29,13 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.format.DateTimeFormat
 import kotlinx.datetime.format.char
 
+/**
+ * A state holder for [SimpleDateInput] that manages the currently selected date and synchronizes
+ * it with the text field value.
+ *
+ * Use [rememberSimpleDateInputState] to create an instance that survives recompositions and
+ * configuration changes.
+ */
 @Stable
 public interface SimpleDateInputState {
 
@@ -55,6 +62,17 @@ public interface SimpleDateInputState {
     public fun updateFieldValue(newValue: String)
 }
 
+/**
+ * Creates a [SimpleDateInputState] that is remembered across compositions.
+ *
+ * @param initialSelectedDate The initial [LocalDate] to be selected, or `null` if no date is
+ * selected.
+ * @param dateFormat The [DateTimeFormat] used to parse typed input and format the date when
+ * [SimpleDateInputState.selectedDate] is set programmatically. Defaults to `MM/yyyy`.
+ * @param onFieldValidation Callback invoked whenever the state attempts to parse typed input or
+ * to format [SimpleDateInputState.selectedDate]. Receives `true` when parsing or formatting
+ * succeeds, `false` when it fails, or `null` when the field is empty.
+ */
 @Composable
 public fun rememberSimpleDateInputState(
     initialSelectedDate: LocalDate? = null,

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputState.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputState.kt
@@ -26,23 +26,21 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.gabrieldrn.carbon.datepicker.SimpleDateInputStateImpl.Companion.Saver
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.YearMonth
 import kotlinx.datetime.format.DateTimeFormat
 import kotlinx.datetime.format.char
 
 /**
  * A state holder for [SimpleDateInput] that manages the currently selected date and synchronizes
  * it with the text field value.
- *
- * Use [rememberSimpleDateInputState] to create an instance that survives recompositions and
- * configuration changes.
  */
 @Stable
-public interface SimpleDateInputState {
+public interface SimpleDateInputState<T> {
 
     /**
-     * The currently selected [LocalDate], or `null` if no date is selected.
+     * The currently selected date, or `null` if no date is selected.
      */
-    public var selectedDate: LocalDate?
+    public var selectedDate: T?
 
     /**
      * A callback invoked by the state to update the text field value, usually when the selected
@@ -63,24 +61,59 @@ public interface SimpleDateInputState {
 }
 
 /**
- * Creates a [SimpleDateInputState] that is remembered across compositions.
+ * Creates a [SimpleDateInputState] that is remembered across compositions for precise dates
+ * (day, month and year). Uses `kotlinx.datetime`'s [LocalDate] as the date type.
  *
  * @param initialSelectedDate The initial [LocalDate] to be selected, or `null` if no date is
  * selected.
  * @param dateFormat The [DateTimeFormat] used to parse typed input and format the date when
- * [SimpleDateInputState.selectedDate] is set programmatically. Defaults to `MM/yyyy`.
+ * [SimpleDateInputState.selectedDate] is set programmatically. Defaults to `dd/MM/yyyy`.
  * @param onFieldValidation Callback invoked whenever the state attempts to parse typed input or
  * to format [SimpleDateInputState.selectedDate]. Receives `true` when parsing or formatting
  * succeeds, `false` when it fails, or `null` when the field is empty.
  */
 @Composable
-public fun rememberSimpleDateInputState(
+public fun rememberMemorableSimpleDateInputState(
     initialSelectedDate: LocalDate? = null,
     dateFormat: DateTimeFormat<LocalDate> = LocalDate.Format {
+        day(); char('/'); monthNumber(); char( '/'); year()
+    },
+    onFieldValidation: (Boolean?) -> Unit = {}
+): SimpleDateInputState<LocalDate> = rememberSaveable(
+    dateFormat,
+    onFieldValidation,
+    saver = SimpleDateInputStateImpl.Saver(
+        dateFormat = dateFormat,
+        onFieldValidation = onFieldValidation
+    )
+) {
+    SimpleDateInputStateImpl(
+        initialSelectedDate = initialSelectedDate,
+        dateFormat = dateFormat,
+        onFieldValidation = onFieldValidation
+    )
+}
+
+/**
+ * Creates a [SimpleDateInputState] that is remembered across compositions for approximate dates
+ * (month and year only). Uses `kotlinx.datetime`'s [YearMonth] as the date type.
+ *
+ * @param initialSelectedDate The initial [YearMonth] to be selected, or `null` if no date is
+ * selected.
+ * @param dateFormat The [DateTimeFormat] used to parse typed input and format the date when
+ * [SimpleDateInputState.selectedDate] is set programmatically. Defaults to `dd/MM/yyyy`.
+ * @param onFieldValidation Callback invoked whenever the state attempts to parse typed input or
+ * to format [SimpleDateInputState.selectedDate]. Receives `true` when parsing or formatting
+ * succeeds, `false` when it fails, or `null` when the field is empty.
+ */
+@Composable
+public fun rememberApproximateSimpleDateInputState(
+    initialSelectedDate: YearMonth? = null,
+    dateFormat: DateTimeFormat<YearMonth> = YearMonth.Format {
         monthNumber(); char( '/'); year()
     },
     onFieldValidation: (Boolean?) -> Unit = {}
-): SimpleDateInputState = rememberSaveable(
+): SimpleDateInputState<YearMonth> = rememberSaveable(
     dateFormat,
     onFieldValidation,
     saver = SimpleDateInputStateImpl.Saver(
@@ -96,15 +129,15 @@ public fun rememberSimpleDateInputState(
 }
 
 @Stable
-private class SimpleDateInputStateImpl(
-    initialSelectedDate: LocalDate?,
-    val dateFormat: DateTimeFormat<LocalDate>,
+private class SimpleDateInputStateImpl<T>(
+    initialSelectedDate: T?,
+    val dateFormat: DateTimeFormat<T>,
     val onFieldValidation: (Boolean?) -> Unit
-) : SimpleDateInputState {
+) : SimpleDateInputState<T> {
 
     private var _selectedDate by mutableStateOf(initialSelectedDate)
 
-    override var selectedDate: LocalDate?
+    override var selectedDate: T?
         get() = _selectedDate
         set(value) {
             if (value == null) {
@@ -144,14 +177,15 @@ private class SimpleDateInputStateImpl(
         /**
          * Default [Saver] implementation for [SimpleDateInputStateImpl].
          *
+         * @param T The type of date being managed (e.g., [LocalDate] or [YearMonth]).
          * @param dateFormat The [DateTimeFormat] used to parse and format the date string.
          * @param onFieldValidation Callback invoked when the state tries to parse the field value
          * or format the [SimpleDateInputStateImpl.selectedDate] when one of them is changed.
          */
-        fun Saver(
-            dateFormat: DateTimeFormat<LocalDate>,
+        fun <T> Saver(
+            dateFormat: DateTimeFormat<T>,
             onFieldValidation: (Boolean?) -> Unit
-        ): Saver<SimpleDateInputStateImpl, *> = listSaver(
+        ): Saver<SimpleDateInputStateImpl<T>, *> = listSaver(
             save = { listOf(it.selectedDate) },
             restore = {
                 SimpleDateInputStateImpl(

--- a/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputState.kt
+++ b/carbon/src/commonMain/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputState.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.datepicker
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import com.gabrieldrn.carbon.datepicker.SimpleDateInputStateImpl.Companion.Saver
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.format.DateTimeFormat
+import kotlinx.datetime.format.char
+
+@Stable
+public interface SimpleDateInputState {
+
+    /**
+     * The currently selected [LocalDate], or `null` if no date is selected.
+     */
+    public var selectedDate: LocalDate?
+
+    /**
+     * A callback invoked by the state to update the text field value, usually when the selected
+     * date changes.
+     *
+     * This is typically set by the UI component (e.g., a DatePicker text field) to receive updates
+     * when the [selectedDate] changes programmatically or via calendar interaction.
+     * The argument is the formatted date string or the raw input string.
+     */
+    public var updateFieldCallback: ((String) -> Unit)?
+
+    /**
+     * Processes a new string value input (e.g., from a text field).
+     *
+     * @param newValue The raw string input to process.
+     */
+    public fun updateFieldValue(newValue: String)
+}
+
+@Composable
+public fun rememberSimpleDateInputState(
+    initialSelectedDate: LocalDate? = null,
+    dateFormat: DateTimeFormat<LocalDate> = LocalDate.Format {
+        monthNumber(); char( '/'); year()
+    },
+    onFieldValidation: (Boolean?) -> Unit = {}
+): SimpleDateInputState = rememberSaveable(
+    dateFormat,
+    onFieldValidation,
+    saver = SimpleDateInputStateImpl.Saver(
+        dateFormat = dateFormat,
+        onFieldValidation = onFieldValidation
+    )
+) {
+    SimpleDateInputStateImpl(
+        initialSelectedDate = initialSelectedDate,
+        dateFormat = dateFormat,
+        onFieldValidation = onFieldValidation
+    )
+}
+
+@Stable
+private class SimpleDateInputStateImpl(
+    initialSelectedDate: LocalDate?,
+    val dateFormat: DateTimeFormat<LocalDate>,
+    val onFieldValidation: (Boolean?) -> Unit
+) : SimpleDateInputState {
+
+    private var _selectedDate by mutableStateOf(initialSelectedDate)
+
+    override var selectedDate: LocalDate?
+        get() = _selectedDate
+        set(value) {
+            if (value == null) {
+                updateFieldCallback?.invoke("")
+                onFieldValidation(null)
+                _selectedDate = null
+            } else {
+                try {
+                    updateFieldCallback?.invoke(dateFormat.format(value))
+                    onFieldValidation(true)
+                    _selectedDate = value
+                } catch (_: IllegalArgumentException) {
+                    onFieldValidation(false)
+                }
+            }
+        }
+
+    override var updateFieldCallback: ((String) -> Unit)? = null
+
+    override fun updateFieldValue(newValue: String) {
+        if (newValue.isBlank()) {
+            onFieldValidation(null)
+            _selectedDate = null
+        } else {
+            try {
+                _selectedDate = dateFormat.parse(newValue)
+                onFieldValidation(true)
+            } catch (_: IllegalArgumentException) {
+                onFieldValidation(false)
+            }
+        }
+        updateFieldCallback?.invoke(newValue)
+    }
+
+    companion object {
+
+        /**
+         * Default [Saver] implementation for [SimpleDateInputStateImpl].
+         *
+         * @param dateFormat The [DateTimeFormat] used to parse and format the date string.
+         * @param onFieldValidation Callback invoked when the state tries to parse the field value
+         * or format the [SimpleDateInputStateImpl.selectedDate] when one of them is changed.
+         */
+        fun Saver(
+            dateFormat: DateTimeFormat<LocalDate>,
+            onFieldValidation: (Boolean?) -> Unit
+        ): Saver<SimpleDateInputStateImpl, *> = listSaver(
+            save = { listOf(it.selectedDate) },
+            restore = {
+                SimpleDateInputStateImpl(
+                    initialSelectedDate = it[0],
+                    dateFormat = dateFormat,
+                    onFieldValidation = onFieldValidation
+                )
+            }
+        )
+    }
+}

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputTest.kt
@@ -33,6 +33,8 @@ import com.gabrieldrn.carbon.textinput.TextInputState
 import com.gabrieldrn.carbon.textinput.TextInputTestTags
 import com.gabrieldrn.carbon.textinput.runGlobalTextInputLayoutAssertions
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
+import kotlinx.datetime.YearMonth
 import kotlinx.datetime.format.char
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -40,8 +42,12 @@ import kotlin.test.assertNull
 
 class SimpleDateInputTest {
 
-    private val dateFormat = LocalDate.Format {
+    private val memorableDateFormat = LocalDate.Format {
         monthNumber(); char('/'); day(); char('/'); year()
+    }
+
+    private val approximateDateFormat = YearMonth.Format {
+        monthNumber(); char('/'); year()
     }
 
     private var _value by mutableStateOf("")
@@ -49,12 +55,14 @@ class SimpleDateInputTest {
     private var _helperText by mutableStateOf("")
     private var _inputState by mutableStateOf(TextInputState.Enabled)
 
+    // region Layout and semantics
+
     @Test
     fun simpleDateInput_validateLayout() = runComposeUiTest {
         setContent {
             CarbonDesignSystem {
                 SimpleDateInput(
-                    state = rememberSimpleDateInputState(dateFormat = dateFormat),
+                    state = rememberMemorableSimpleDateInputState(dateFormat = memorableDateFormat),
                     label = "Date",
                     value = _value,
                     onValueChange = {},
@@ -92,7 +100,7 @@ class SimpleDateInputTest {
         setContent {
             CarbonDesignSystem {
                 SimpleDateInput(
-                    state = rememberSimpleDateInputState(dateFormat = dateFormat),
+                    state = rememberMemorableSimpleDateInputState(dateFormat = memorableDateFormat),
                     label = "Date",
                     value = _value,
                     onValueChange = {},
@@ -119,16 +127,20 @@ class SimpleDateInputTest {
         }
     }
 
+    // endregion
+
+    // region Memorable date (LocalDate)
+
     @Test
-    fun simpleDateInput_whenValidDateEntered_validateParsing() = runComposeUiTest {
+    fun simpleDateInput_memorable_whenValidDateEntered_validateParsing() = runComposeUiTest {
         var validationResult: Boolean? = null
-        var state: SimpleDateInputState? = null
+        var state: SimpleDateInputState<LocalDate>? = null
         var fieldValue by mutableStateOf("")
 
         setContent {
             CarbonDesignSystem {
-                state = rememberSimpleDateInputState(
-                    dateFormat = dateFormat,
+                state = rememberMemorableSimpleDateInputState(
+                    dateFormat = memorableDateFormat,
                     onFieldValidation = remember { { validationResult = it } }
                 )
                 SimpleDateInput(
@@ -154,15 +166,15 @@ class SimpleDateInputTest {
     }
 
     @Test
-    fun simpleDateInput_whenInvalidDateEntered_validateError() = runComposeUiTest {
+    fun simpleDateInput_memorable_whenInvalidDateEntered_validateError() = runComposeUiTest {
         var validationResult: Boolean? = null
-        var state: SimpleDateInputState? = null
+        var state: SimpleDateInputState<LocalDate>? = null
         var fieldValue by mutableStateOf("")
 
         setContent {
             CarbonDesignSystem {
-                state = rememberSimpleDateInputState(
-                    dateFormat = dateFormat,
+                state = rememberMemorableSimpleDateInputState(
+                    dateFormat = memorableDateFormat,
                     onFieldValidation = remember { { validationResult = it } }
                 )
                 SimpleDateInput(
@@ -188,16 +200,16 @@ class SimpleDateInputTest {
     }
 
     @Test
-    fun simpleDateInput_whenBlankEntered_validateNullValidation() = runComposeUiTest {
+    fun simpleDateInput_memorable_whenBlankEntered_validateNullValidation() = runComposeUiTest {
         var validationResult: Boolean? = true
-        var state: SimpleDateInputState? = null
+        var state: SimpleDateInputState<LocalDate>? = null
         var fieldValue by mutableStateOf("")
 
         setContent {
             CarbonDesignSystem {
-                state = rememberSimpleDateInputState(
+                state = rememberMemorableSimpleDateInputState(
                     initialSelectedDate = LocalDate(2024, 6, 15),
-                    dateFormat = dateFormat,
+                    dateFormat = memorableDateFormat,
                     onFieldValidation = remember { { validationResult = it } }
                 )
                 SimpleDateInput(
@@ -220,18 +232,18 @@ class SimpleDateInputTest {
     }
 
     @Test
-    fun simpleDateInput_withInitialDate_validateDisplay() = runComposeUiTest {
+    fun simpleDateInput_memorable_withInitialDate_validateDisplay() = runComposeUiTest {
         val initialDate = LocalDate(2024, 3, 20)
-        var state: SimpleDateInputState? = null
+        var state: SimpleDateInputState<LocalDate>? = null
         var fieldValue by mutableStateOf("")
 
         setContent {
             CarbonDesignSystem {
-                state = rememberSimpleDateInputState(
+                state = rememberMemorableSimpleDateInputState(
                     initialSelectedDate = initialDate,
-                    dateFormat = dateFormat,
+                    dateFormat = memorableDateFormat,
                 )
-                fieldValue = state.selectedDate?.let { dateFormat.format(it) } ?: ""
+                fieldValue = state.selectedDate?.let { memorableDateFormat.format(it) } ?: ""
                 SimpleDateInput(
                     state = state,
                     label = "Date",
@@ -248,18 +260,18 @@ class SimpleDateInputTest {
     }
 
     @Test
-    fun simpleDateInput_clearDate_validateEmptyField() = runComposeUiTest {
+    fun simpleDateInput_memorable_clearDate_validateEmptyField() = runComposeUiTest {
         val initialDate = LocalDate(2024, 5, 10)
-        var state: SimpleDateInputState? = null
+        var state: SimpleDateInputState<LocalDate>? = null
         var fieldValue by mutableStateOf("")
 
         setContent {
             CarbonDesignSystem {
-                state = rememberSimpleDateInputState(
+                state = rememberMemorableSimpleDateInputState(
                     initialSelectedDate = initialDate,
-                    dateFormat = dateFormat,
+                    dateFormat = memorableDateFormat,
                 )
-                fieldValue = state.selectedDate?.let { dateFormat.format(it) } ?: ""
+                fieldValue = state.selectedDate?.let { memorableDateFormat.format(it) } ?: ""
                 SimpleDateInput(
                     state = state,
                     label = "Date",
@@ -280,15 +292,54 @@ class SimpleDateInputTest {
     }
 
     @Test
-    fun simpleDateInput_whenDateSetProgrammatically_validateFieldUpdated() = runComposeUiTest {
+    fun simpleDateInput_memorable_whenDateSetProgrammatically_validateFieldUpdated() =
+        runComposeUiTest {
+            var validationResult: Boolean? = null
+            var state: SimpleDateInputState<LocalDate>? = null
+            var fieldValue by mutableStateOf("")
+
+            setContent {
+                CarbonDesignSystem {
+                    state = rememberMemorableSimpleDateInputState(
+                        dateFormat = memorableDateFormat,
+                        onFieldValidation = remember { { validationResult = it } }
+                    )
+                    SimpleDateInput(
+                        state = state,
+                        label = "Date",
+                        value = fieldValue,
+                        onValueChange = { fieldValue = it },
+                    )
+                }
+            }
+
+            val newDate = LocalDate(2025, 12, 1)
+
+            runOnIdle {
+                state?.selectedDate = newDate
+            }
+
+            waitForIdle()
+
+            assertEquals(true, validationResult)
+            assertEquals(newDate, state?.selectedDate)
+            assertEquals("12/01/2025", fieldValue)
+        }
+
+    // endregion
+
+    // region Approximate date (YearMonth)
+
+    @Test
+    fun simpleDateInput_approximate_whenValidDateEntered_validateParsing() = runComposeUiTest {
         var validationResult: Boolean? = null
-        var state: SimpleDateInputState? = null
+        var state: SimpleDateInputState<YearMonth>? = null
         var fieldValue by mutableStateOf("")
 
         setContent {
             CarbonDesignSystem {
-                state = rememberSimpleDateInputState(
-                    dateFormat = dateFormat,
+                state = rememberApproximateSimpleDateInputState(
+                    dateFormat = approximateDateFormat,
                     onFieldValidation = remember { { validationResult = it } }
                 )
                 SimpleDateInput(
@@ -300,16 +351,179 @@ class SimpleDateInputTest {
             }
         }
 
-        val newDate = LocalDate(2025, 12, 1)
+        val validDateString = "06/2024"
 
         runOnIdle {
-            state?.selectedDate = newDate
+            state?.updateFieldValue(validDateString)
         }
 
         waitForIdle()
 
-        assertEquals(true, validationResult)
-        assertEquals(newDate, state?.selectedDate)
-        assertEquals("12/01/2025", fieldValue)
+        assertEquals(true, validationResult, "Valid year-month should be parsed successfully")
+        assertEquals(YearMonth(2024, Month.JUNE), state?.selectedDate)
+        assertEquals(validDateString, fieldValue)
     }
+
+    @Test
+    fun simpleDateInput_approximate_whenInvalidDateEntered_validateError() = runComposeUiTest {
+        var validationResult: Boolean? = null
+        var state: SimpleDateInputState<YearMonth>? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberApproximateSimpleDateInputState(
+                    dateFormat = approximateDateFormat,
+                    onFieldValidation = remember { { validationResult = it } }
+                )
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        val invalidDateString = "not-a-date"
+
+        runOnIdle {
+            state?.updateFieldValue(invalidDateString)
+        }
+
+        waitForIdle()
+
+        assertEquals(false, validationResult, "Invalid year-month should fail validation")
+        assertNull(state?.selectedDate, "Selected date should remain null for invalid input")
+        assertEquals(invalidDateString, fieldValue, "Field value should still be updated")
+    }
+
+    @Test
+    fun simpleDateInput_approximate_whenBlankEntered_validateNullValidation() = runComposeUiTest {
+        var validationResult: Boolean? = true
+        var state: SimpleDateInputState<YearMonth>? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberApproximateSimpleDateInputState(
+                    initialSelectedDate = YearMonth(2024, Month.JUNE),
+                    dateFormat = approximateDateFormat,
+                    onFieldValidation = remember { { validationResult = it } }
+                )
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        runOnIdle {
+            state?.updateFieldValue("   ")
+        }
+
+        waitForIdle()
+
+        assertNull(validationResult, "Blank input should yield null validation result")
+        assertNull(state?.selectedDate, "Selected date should be cleared on blank input")
+    }
+
+    @Test
+    fun simpleDateInput_approximate_withInitialDate_validateDisplay() = runComposeUiTest {
+        val initialDate = YearMonth(2024, Month.MARCH)
+        var state: SimpleDateInputState<YearMonth>? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberApproximateSimpleDateInputState(
+                    initialSelectedDate = initialDate,
+                    dateFormat = approximateDateFormat,
+                )
+                fieldValue = state.selectedDate?.let { approximateDateFormat.format(it) } ?: ""
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        waitForIdle()
+
+        assertEquals(initialDate, state?.selectedDate)
+        assertEquals("03/2024", fieldValue)
+    }
+
+    @Test
+    fun simpleDateInput_approximate_clearDate_validateEmptyField() = runComposeUiTest {
+        val initialDate = YearMonth(2024, Month.MAY)
+        var state: SimpleDateInputState<YearMonth>? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberApproximateSimpleDateInputState(
+                    initialSelectedDate = initialDate,
+                    dateFormat = approximateDateFormat,
+                )
+                fieldValue = state.selectedDate?.let { approximateDateFormat.format(it) } ?: ""
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        runOnIdle {
+            state?.selectedDate = null
+        }
+
+        waitForIdle()
+
+        assertNull(state?.selectedDate)
+        assertEquals("", fieldValue)
+    }
+
+    @Test
+    fun simpleDateInput_approximate_whenDateSetProgrammatically_validateFieldUpdated() =
+        runComposeUiTest {
+            var validationResult: Boolean? = null
+            var state: SimpleDateInputState<YearMonth>? = null
+            var fieldValue by mutableStateOf("")
+
+            setContent {
+                CarbonDesignSystem {
+                    state = rememberApproximateSimpleDateInputState(
+                        dateFormat = approximateDateFormat,
+                        onFieldValidation = remember { { validationResult = it } }
+                    )
+                    SimpleDateInput(
+                        state = state,
+                        label = "Date",
+                        value = fieldValue,
+                        onValueChange = { fieldValue = it },
+                    )
+                }
+            }
+
+            val newDate = YearMonth(2025, Month.DECEMBER)
+
+            runOnIdle {
+                state?.selectedDate = newDate
+            }
+
+            waitForIdle()
+
+            assertEquals(true, validationResult)
+            assertEquals(newDate, state?.selectedDate)
+            assertEquals("12/2025", fieldValue)
+        }
+
+    // endregion
 }

--- a/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputTest.kt
+++ b/carbon/src/commonTest/kotlin/com/gabrieldrn/carbon/datepicker/SimpleDateInputTest.kt
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2026 Gabriel Derrien
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gabrieldrn.carbon.datepicker
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.isFocusable
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import com.gabrieldrn.carbon.CarbonDesignSystem
+import com.gabrieldrn.carbon.forEachParameter
+import com.gabrieldrn.carbon.test.semantics.isReadOnly
+import com.gabrieldrn.carbon.textinput.TextInputState
+import com.gabrieldrn.carbon.textinput.TextInputTestTags
+import com.gabrieldrn.carbon.textinput.runGlobalTextInputLayoutAssertions
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.format.char
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SimpleDateInputTest {
+
+    private val dateFormat = LocalDate.Format {
+        monthNumber(); char('/'); day(); char('/'); year()
+    }
+
+    private var _value by mutableStateOf("")
+    private var _placeholderText by mutableStateOf("")
+    private var _helperText by mutableStateOf("")
+    private var _inputState by mutableStateOf(TextInputState.Enabled)
+
+    @Test
+    fun simpleDateInput_validateLayout() = runComposeUiTest {
+        setContent {
+            CarbonDesignSystem {
+                SimpleDateInput(
+                    state = rememberSimpleDateInputState(dateFormat = dateFormat),
+                    label = "Date",
+                    value = _value,
+                    onValueChange = {},
+                    placeholderText = _placeholderText,
+                    helperText = _helperText,
+                    inputState = _inputState,
+                )
+            }
+        }
+
+        forEachParameter(
+            aValues = arrayOf("", "06/15/2024"),
+            bValues = arrayOf("", "mm/dd/yyyy"),
+            cValues = arrayOf("", "Helper text"),
+            dValues = TextInputState.entries.toTypedArray()
+        ) { value, placeholderText, helperText, inputState ->
+
+            _value = value
+            _placeholderText = placeholderText
+            _helperText = helperText
+            _inputState = inputState
+
+            waitForIdle()
+
+            runGlobalTextInputLayoutAssertions(
+                label = "Date",
+                helperText = helperText,
+                state = inputState,
+            )
+        }
+    }
+
+    @Test
+    fun simpleDateInput_validateSemantics() = runComposeUiTest {
+        setContent {
+            CarbonDesignSystem {
+                SimpleDateInput(
+                    state = rememberSimpleDateInputState(dateFormat = dateFormat),
+                    label = "Date",
+                    value = _value,
+                    onValueChange = {},
+                    inputState = _inputState,
+                )
+            }
+        }
+
+        TextInputState.entries.forEach { inputState ->
+            _inputState = inputState
+
+            waitForIdle()
+
+            onNodeWithTag(TextInputTestTags.FIELD, useUnmergedTree = true).run {
+                when (inputState) {
+                    TextInputState.Disabled -> assertIsNotEnabled()
+                    TextInputState.ReadOnly -> {
+                        assert(isFocusable())
+                        assert(isReadOnly())
+                    }
+                    else -> assertIsEnabled()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun simpleDateInput_whenValidDateEntered_validateParsing() = runComposeUiTest {
+        var validationResult: Boolean? = null
+        var state: SimpleDateInputState? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberSimpleDateInputState(
+                    dateFormat = dateFormat,
+                    onFieldValidation = remember { { validationResult = it } }
+                )
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        val validDateString = "06/15/2024"
+
+        runOnIdle {
+            state?.updateFieldValue(validDateString)
+        }
+
+        waitForIdle()
+
+        assertEquals(true, validationResult, "Valid date should be parsed successfully")
+        assertEquals(LocalDate(2024, 6, 15), state?.selectedDate)
+        assertEquals(validDateString, fieldValue)
+    }
+
+    @Test
+    fun simpleDateInput_whenInvalidDateEntered_validateError() = runComposeUiTest {
+        var validationResult: Boolean? = null
+        var state: SimpleDateInputState? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberSimpleDateInputState(
+                    dateFormat = dateFormat,
+                    onFieldValidation = remember { { validationResult = it } }
+                )
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        val invalidDateString = "not-a-date"
+
+        runOnIdle {
+            state?.updateFieldValue(invalidDateString)
+        }
+
+        waitForIdle()
+
+        assertEquals(false, validationResult, "Invalid date should fail validation")
+        assertNull(state?.selectedDate, "Selected date should remain null for invalid input")
+        assertEquals(invalidDateString, fieldValue, "Field value should still be updated")
+    }
+
+    @Test
+    fun simpleDateInput_whenBlankEntered_validateNullValidation() = runComposeUiTest {
+        var validationResult: Boolean? = true
+        var state: SimpleDateInputState? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberSimpleDateInputState(
+                    initialSelectedDate = LocalDate(2024, 6, 15),
+                    dateFormat = dateFormat,
+                    onFieldValidation = remember { { validationResult = it } }
+                )
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        runOnIdle {
+            state?.updateFieldValue("   ")
+        }
+
+        waitForIdle()
+
+        assertNull(validationResult, "Blank input should yield null validation result")
+        assertNull(state?.selectedDate, "Selected date should be cleared on blank input")
+    }
+
+    @Test
+    fun simpleDateInput_withInitialDate_validateDisplay() = runComposeUiTest {
+        val initialDate = LocalDate(2024, 3, 20)
+        var state: SimpleDateInputState? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberSimpleDateInputState(
+                    initialSelectedDate = initialDate,
+                    dateFormat = dateFormat,
+                )
+                fieldValue = state.selectedDate?.let { dateFormat.format(it) } ?: ""
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        waitForIdle()
+
+        assertEquals(initialDate, state?.selectedDate)
+        assertEquals("03/20/2024", fieldValue)
+    }
+
+    @Test
+    fun simpleDateInput_clearDate_validateEmptyField() = runComposeUiTest {
+        val initialDate = LocalDate(2024, 5, 10)
+        var state: SimpleDateInputState? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberSimpleDateInputState(
+                    initialSelectedDate = initialDate,
+                    dateFormat = dateFormat,
+                )
+                fieldValue = state.selectedDate?.let { dateFormat.format(it) } ?: ""
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        runOnIdle {
+            state?.selectedDate = null
+        }
+
+        waitForIdle()
+
+        assertNull(state?.selectedDate)
+        assertEquals("", fieldValue)
+    }
+
+    @Test
+    fun simpleDateInput_whenDateSetProgrammatically_validateFieldUpdated() = runComposeUiTest {
+        var validationResult: Boolean? = null
+        var state: SimpleDateInputState? = null
+        var fieldValue by mutableStateOf("")
+
+        setContent {
+            CarbonDesignSystem {
+                state = rememberSimpleDateInputState(
+                    dateFormat = dateFormat,
+                    onFieldValidation = remember { { validationResult = it } }
+                )
+                SimpleDateInput(
+                    state = state,
+                    label = "Date",
+                    value = fieldValue,
+                    onValueChange = { fieldValue = it },
+                )
+            }
+        }
+
+        val newDate = LocalDate(2025, 12, 1)
+
+        runOnIdle {
+            state?.selectedDate = newDate
+        }
+
+        waitForIdle()
+
+        assertEquals(true, validationResult)
+        assertEquals(newDate, state?.selectedDate)
+        assertEquals("12/01/2025", fieldValue)
+    }
+}

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/datepicker/DatePickerDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/datepicker/DatePickerDemoScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.gabrieldrn.carbon.Carbon
 import com.gabrieldrn.carbon.catalog.Res
 import com.gabrieldrn.carbon.catalog.common.DemoScreen
@@ -38,8 +40,9 @@ import com.gabrieldrn.carbon.catalog.ic_unknown_filled
 import com.gabrieldrn.carbon.catalog.ic_warning_filled
 import com.gabrieldrn.carbon.datepicker.CalendarDatePicker
 import com.gabrieldrn.carbon.datepicker.SimpleDateInput
+import com.gabrieldrn.carbon.datepicker.rememberApproximateSimpleDateInputState
 import com.gabrieldrn.carbon.datepicker.rememberCalendarDatePickerState
-import com.gabrieldrn.carbon.datepicker.rememberSimpleDateInputState
+import com.gabrieldrn.carbon.datepicker.rememberMemorableSimpleDateInputState
 import com.gabrieldrn.carbon.dropdown.Dropdown
 import com.gabrieldrn.carbon.dropdown.base.toDropdownOptions
 import com.gabrieldrn.carbon.foundation.color.CarbonLayer
@@ -53,14 +56,16 @@ import com.gabrieldrn.carbon.textinput.TextInputState
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.YearMonth
 import kotlinx.datetime.format.char
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.yearMonth
 import org.jetbrains.compose.resources.painterResource
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
-enum class DatePickerVariant(val label: String) {
+private enum class DatePickerVariant(val label: String) {
     DateInput("Date input"),
     CalendarDatePicker("Calendar date picker");
 
@@ -69,24 +74,30 @@ enum class DatePickerVariant(val label: String) {
     }
 }
 
+private enum class SimpleDateInputType { Memorable, Approximate }
+
 private val variants = DatePickerVariant.entries.map { TabItem(it.label) }
 
 private val textInputStateOptions = TextInputState.entries.toDropdownOptions()
+private val simpleDateInputOptions = SimpleDateInputType.entries.toDropdownOptions()
 
 private val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
 
-private val dateFormat =
+private val localDateFormat =
     LocalDate.Format { year(); char('/'); monthNumber(); char('/'); day() }
+
+private val yearMonthFormat =
+    YearMonth.Format { monthNumber(); char('/'); year() }
 
 @OptIn(ExperimentalTime::class)
 @Composable
 fun DatePickerDemoScreen(
     modifier: Modifier = Modifier
 ) {
-    var isExpanded by remember { mutableStateOf(false) }
     var isFieldValid by remember { mutableStateOf<Boolean?>(null) }
 
     var inputState by remember { mutableStateOf(TextInputState.Enabled) }
+    var simpleDateInputType by remember { mutableStateOf(SimpleDateInputType.Memorable) }
 
     val effectiveInputState = remember(inputState, isFieldValid) {
         when (inputState) {
@@ -99,94 +110,31 @@ fun DatePickerDemoScreen(
     DemoScreen(
         variants = variants,
         demoContent = { tab ->
-            val variant = DatePickerVariant.fromLabel(tab.label)
+            val datePickerVariant = DatePickerVariant.fromLabel(tab.label)
 
-            LaunchedEffect(variant) {
+            LaunchedEffect(datePickerVariant) {
                 inputState = TextInputState.Enabled
                 isFieldValid = null
             }
 
-            when (variant) {
-                DatePickerVariant.DateInput -> {
-                    val state = rememberSimpleDateInputState(
-                        dateFormat = dateFormat,
-                        onFieldValidation = remember { { isFieldValid = it } }
-                    )
-
-                    var fieldValue by remember {
-                        mutableStateOf(
-                            state
-                                .selectedDate
-                                ?.let(dateFormat::format)
-                                ?: ""
-                        )
-                    }
-
-                    SimpleDateInput(
-                        state = state,
-                        label = "Label",
-                        placeholderText = "yyyy/mm/dd",
-                        helperText = "year/month/day",
-                        value = fieldValue,
-                        inputState = effectiveInputState,
-                        onValueChange = { fieldValue = it },
-                        modifier = Modifier.padding(vertical = SpacingScale.spacing07)
-                    )
-
-                    CarbonLayer {
-                        FieldDebugSection(
-                            isFieldValid = isFieldValid,
-                            inputValue = state.selectedDate.toString().uppercase(),
-                            modifier = Modifier.padding(top = SpacingScale.spacing05)
-                        )
-                    }
-                }
-                DatePickerVariant.CalendarDatePicker -> {
-                    LaunchedEffect(variant) {
-                        isExpanded = false
-                    }
-
-                    val state = rememberCalendarDatePickerState(
-                        today = today,
-                        dateFormat = dateFormat,
-                        selectableDates = { it != today.plus(1, DateTimeUnit.DAY) },
-                        onFieldValidation = remember { { isFieldValid = it } }
-                    )
-
-                    var fieldValue by remember {
-                        mutableStateOf(
-                            state
-                                .selectedDate
-                                ?.let(dateFormat::format)
-                                ?: ""
-                        )
-                    }
-
-                    CalendarDatePicker(
-                        datePickerState = state,
-                        label = "Label",
-                        value = fieldValue,
-                        expanded = isExpanded,
-                        placeholderText = "yyyy/mm/dd",
-                        helperText = "year/month/day",
-                        inputState = effectiveInputState,
-                        onValueChange = { fieldValue = it },
-                        onExpandedChange = { isExpanded = it },
-                        onDismissRequest = { isExpanded = false },
-                        modifier = Modifier.padding(vertical = SpacingScale.spacing07)
-                    )
-
-                    CarbonLayer {
-                        FieldDebugSection(
-                            isFieldValid = isFieldValid,
-                            inputValue = state.selectedDate.toString().uppercase(),
-                            modifier = Modifier.padding(top = SpacingScale.spacing05)
-                        )
-                    }
-                }
+            when (datePickerVariant) {
+                DatePickerVariant.DateInput -> SimpleDateInputDemo(
+                    simpleDateInputType = simpleDateInputType,
+                    effectiveInputState = effectiveInputState,
+                    isFieldValid = isFieldValid,
+                    onFieldValidation = remember { { isFieldValid = it } }
+                )
+                DatePickerVariant.CalendarDatePicker -> CalendarDatePickerDemo(
+                    variant = datePickerVariant,
+                    effectiveInputState = effectiveInputState,
+                    isFieldValid = isFieldValid,
+                    onFieldValidation = remember { { isFieldValid = it } }
+                )
             }
         },
-        demoParametersContent = {
+        demoParametersContent = { tab ->
+            val variant = DatePickerVariant.fromLabel(tab.label)
+
             Dropdown(
                 label = "Input state",
                 placeholder = "Choose an option",
@@ -195,13 +143,133 @@ fun DatePickerDemoScreen(
                 onOptionSelected = { inputState = it }
             )
 
-            BasicText(
-                text = "Picker state data",
-                style = Carbon.typography.heading01.copy(color = Carbon.theme.textPrimary),
-            )
+            if (variant == DatePickerVariant.DateInput) {
+                Dropdown(
+                    label = "Date type",
+                    placeholder = "Choose an option",
+                    options = simpleDateInputOptions,
+                    selectedOption = simpleDateInputType,
+                    onOptionSelected = { simpleDateInputType = it }
+                )
+            }
         },
         modifier = modifier
     )
+}
+
+@Composable
+private fun SimpleDateInputDemo(
+    simpleDateInputType: SimpleDateInputType,
+    effectiveInputState: TextInputState,
+    isFieldValid: Boolean?,
+    onFieldValidation: (Boolean?) -> Unit
+) {
+    val state = when (simpleDateInputType) {
+        SimpleDateInputType.Memorable -> rememberMemorableSimpleDateInputState(
+            today,
+            localDateFormat,
+            onFieldValidation = onFieldValidation
+        )
+        SimpleDateInputType.Approximate -> rememberApproximateSimpleDateInputState(
+            today.yearMonth,
+            yearMonthFormat,
+
+            )
+    }
+
+    var fieldValue by remember(state) {
+        mutableStateOf(
+            state
+                .selectedDate
+                ?.let {
+                    when (it) {
+                        is LocalDate -> localDateFormat.format(it)
+                        is YearMonth -> yearMonthFormat.format(it)
+                        else -> ""
+                    }
+                }
+                ?: ""
+        )
+    }
+
+    SimpleDateInput(
+        state = state,
+        label = "Label",
+        placeholderText = when (simpleDateInputType) {
+            SimpleDateInputType.Memorable -> "yyyy/mm/dd"
+            SimpleDateInputType.Approximate -> "mm/yyyy"
+        },
+        helperText = when (simpleDateInputType) {
+            SimpleDateInputType.Memorable -> "year/month/day"
+            SimpleDateInputType.Approximate -> "month/year"
+        },
+        value = fieldValue,
+        inputState = effectiveInputState,
+        onValueChange = { fieldValue = it },
+        modifier = Modifier
+            .width(288.dp)
+            .padding(vertical = SpacingScale.spacing07)
+    )
+
+    CarbonLayer {
+        FieldDebugSection(
+            isFieldValid = isFieldValid,
+            inputValue = state.selectedDate.toString().uppercase(),
+            modifier = Modifier.padding(top = SpacingScale.spacing05)
+        )
+    }
+}
+
+@Composable
+private fun CalendarDatePickerDemo(
+    variant: DatePickerVariant,
+    effectiveInputState: TextInputState,
+    isFieldValid: Boolean?,
+    onFieldValidation: (Boolean?) -> Unit
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(variant) {
+        isExpanded = false
+    }
+
+    val state = rememberCalendarDatePickerState(
+        today = today,
+        dateFormat = localDateFormat,
+        selectableDates = { it != today.plus(1, DateTimeUnit.DAY) },
+        onFieldValidation = onFieldValidation
+    )
+
+    var fieldValue by remember {
+        mutableStateOf(
+            state
+                .selectedDate
+                ?.let(localDateFormat::format)
+                ?: ""
+        )
+    }
+
+    CalendarDatePicker(
+        datePickerState = state,
+        label = "Label",
+        value = fieldValue,
+        expanded = isExpanded,
+        placeholderText = "yyyy/mm/dd",
+        helperText = "year/month/day",
+        inputState = effectiveInputState,
+        onValueChange = { fieldValue = it },
+        onExpandedChange = { isExpanded = it },
+        onDismissRequest = { isExpanded = false },
+        modifier = Modifier.padding(vertical = SpacingScale.spacing07)
+    )
+
+    CarbonLayer {
+        FieldDebugSection(
+            isFieldValid = isFieldValid,
+            inputValue = state.selectedDate.toString().uppercase(),
+            modifier = Modifier.padding(top = SpacingScale.spacing05)
+        )
+    }
 }
 
 @Composable

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/datepicker/DatePickerDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/datepicker/DatePickerDemoScreen.kt
@@ -186,9 +186,7 @@ fun DatePickerDemoScreen(
                 }
             }
         },
-        demoParametersContent = { tab ->
-            val variant = DatePickerVariant.fromLabel(tab.label)
-
+        demoParametersContent = {
             Dropdown(
                 label = "Input state",
                 placeholder = "Choose an option",

--- a/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/datepicker/DatePickerDemoScreen.kt
+++ b/catalog/src/commonMain/kotlin/com/gabrieldrn/carbon/catalog/datepicker/DatePickerDemoScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,12 +37,15 @@ import com.gabrieldrn.carbon.catalog.ic_checkmark_filled
 import com.gabrieldrn.carbon.catalog.ic_unknown_filled
 import com.gabrieldrn.carbon.catalog.ic_warning_filled
 import com.gabrieldrn.carbon.datepicker.CalendarDatePicker
+import com.gabrieldrn.carbon.datepicker.SimpleDateInput
 import com.gabrieldrn.carbon.datepicker.rememberCalendarDatePickerState
+import com.gabrieldrn.carbon.datepicker.rememberSimpleDateInputState
 import com.gabrieldrn.carbon.dropdown.Dropdown
 import com.gabrieldrn.carbon.dropdown.base.toDropdownOptions
 import com.gabrieldrn.carbon.foundation.color.CarbonLayer
 import com.gabrieldrn.carbon.foundation.color.layerBackground
 import com.gabrieldrn.carbon.foundation.spacing.SpacingScale
+import com.gabrieldrn.carbon.tab.TabItem
 import com.gabrieldrn.carbon.tag.ReadOnlyTag
 import com.gabrieldrn.carbon.tag.TagSize
 import com.gabrieldrn.carbon.tag.TagType
@@ -56,7 +60,23 @@ import org.jetbrains.compose.resources.painterResource
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+enum class DatePickerVariant(val label: String) {
+    DateInput("Date input"),
+    CalendarDatePicker("Calendar date picker");
+
+    companion object {
+        fun fromLabel(label: String) = DatePickerVariant.entries.first { it.label == label }
+    }
+}
+
+private val variants = DatePickerVariant.entries.map { TabItem(it.label) }
+
 private val textInputStateOptions = TextInputState.entries.toDropdownOptions()
+
+private val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+
+private val dateFormat =
+    LocalDate.Format { year(); char('/'); monthNumber(); char('/'); day() }
 
 @OptIn(ExperimentalTime::class)
 @Composable
@@ -65,27 +85,6 @@ fun DatePickerDemoScreen(
 ) {
     var isExpanded by remember { mutableStateOf(false) }
     var isFieldValid by remember { mutableStateOf<Boolean?>(null) }
-
-    val dateFormat = remember {
-        LocalDate.Format {
-            year(); char('/'); monthNumber(); char('/'); day()
-        }
-    }
-
-    val today = remember {
-        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-    }
-
-    val pickerState = rememberCalendarDatePickerState(
-        today = today,
-        dateFormat = dateFormat,
-        selectableDates = { it != today.plus(1, DateTimeUnit.DAY) },
-        onFieldValidation = remember { { isFieldValid = it } }
-    )
-
-    var fieldValue by remember {
-        mutableStateOf(pickerState.selectedDate?.let(dateFormat::format) ?: "")
-    }
 
     var inputState by remember { mutableStateOf(TextInputState.Enabled) }
 
@@ -98,21 +97,98 @@ fun DatePickerDemoScreen(
     }
 
     DemoScreen(
-        demoContent = {
-            CalendarDatePicker(
-                datePickerState = pickerState,
-                label = "Label",
-                value = fieldValue,
-                expanded = isExpanded,
-                placeholderText = "yyyy/mm/dd",
-                helperText = "year/month/day",
-                inputState = effectiveInputState,
-                onValueChange = { fieldValue = it },
-                onExpandedChange = { isExpanded = it },
-                onDismissRequest = { isExpanded = false },
-            )
+        variants = variants,
+        demoContent = { tab ->
+            val variant = DatePickerVariant.fromLabel(tab.label)
+
+            LaunchedEffect(variant) {
+                inputState = TextInputState.Enabled
+                isFieldValid = null
+            }
+
+            when (variant) {
+                DatePickerVariant.DateInput -> {
+                    val state = rememberSimpleDateInputState(
+                        dateFormat = dateFormat,
+                        onFieldValidation = remember { { isFieldValid = it } }
+                    )
+
+                    var fieldValue by remember {
+                        mutableStateOf(
+                            state
+                                .selectedDate
+                                ?.let(dateFormat::format)
+                                ?: ""
+                        )
+                    }
+
+                    SimpleDateInput(
+                        state = state,
+                        label = "Label",
+                        placeholderText = "yyyy/mm/dd",
+                        helperText = "year/month/day",
+                        value = fieldValue,
+                        inputState = effectiveInputState,
+                        onValueChange = { fieldValue = it },
+                        modifier = Modifier.padding(vertical = SpacingScale.spacing07)
+                    )
+
+                    CarbonLayer {
+                        FieldDebugSection(
+                            isFieldValid = isFieldValid,
+                            inputValue = state.selectedDate.toString().uppercase(),
+                            modifier = Modifier.padding(top = SpacingScale.spacing05)
+                        )
+                    }
+                }
+                DatePickerVariant.CalendarDatePicker -> {
+                    LaunchedEffect(variant) {
+                        isExpanded = false
+                    }
+
+                    val state = rememberCalendarDatePickerState(
+                        today = today,
+                        dateFormat = dateFormat,
+                        selectableDates = { it != today.plus(1, DateTimeUnit.DAY) },
+                        onFieldValidation = remember { { isFieldValid = it } }
+                    )
+
+                    var fieldValue by remember {
+                        mutableStateOf(
+                            state
+                                .selectedDate
+                                ?.let(dateFormat::format)
+                                ?: ""
+                        )
+                    }
+
+                    CalendarDatePicker(
+                        datePickerState = state,
+                        label = "Label",
+                        value = fieldValue,
+                        expanded = isExpanded,
+                        placeholderText = "yyyy/mm/dd",
+                        helperText = "year/month/day",
+                        inputState = effectiveInputState,
+                        onValueChange = { fieldValue = it },
+                        onExpandedChange = { isExpanded = it },
+                        onDismissRequest = { isExpanded = false },
+                        modifier = Modifier.padding(vertical = SpacingScale.spacing07)
+                    )
+
+                    CarbonLayer {
+                        FieldDebugSection(
+                            isFieldValid = isFieldValid,
+                            inputValue = state.selectedDate.toString().uppercase(),
+                            modifier = Modifier.padding(top = SpacingScale.spacing05)
+                        )
+                    }
+                }
+            }
         },
-        demoParametersContent = {
+        demoParametersContent = { tab ->
+            val variant = DatePickerVariant.fromLabel(tab.label)
+
             Dropdown(
                 label = "Input state",
                 placeholder = "Choose an option",
@@ -125,59 +201,64 @@ fun DatePickerDemoScreen(
                 text = "Picker state data",
                 style = Carbon.typography.heading01.copy(color = Carbon.theme.textPrimary),
             )
-
-            CarbonLayer {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .layerBackground()
-                        .padding(SpacingScale.spacing05),
-                    verticalArrangement = Arrangement.spacedBy(SpacingScale.spacing03)
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        BasicText(
-                            text = "Latest field validation event",
-                            style = Carbon.typography.body01.copy(color = Carbon.theme.textHelper),
-                            modifier = Modifier.padding(end = SpacingScale.spacing03)
-                        )
-
-                        when (isFieldValid) {
-                            true -> ReadOnlyTag(
-                                text = "OK",
-                                type = TagType.Green,
-                                icon = { painterResource(Res.drawable.ic_checkmark_filled) },
-                                size = TagSize.Small
-                            )
-                            false -> ReadOnlyTag(
-                                text = "ERROR",
-                                type = TagType.Red,
-                                icon = { painterResource(Res.drawable.ic_warning_filled) },
-                                size = TagSize.Small
-                            )
-                            null -> ReadOnlyTag(
-                                text = "EMPTY",
-                                type = TagType.Gray,
-                                icon = { painterResource(Res.drawable.ic_unknown_filled) },
-                                size = TagSize.Small
-                            )
-                        }
-                    }
-
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        BasicText(
-                            text = "Selected date",
-                            style = Carbon.typography.body01.copy(color = Carbon.theme.textHelper),
-                            modifier = Modifier.padding(end = SpacingScale.spacing03)
-                        )
-
-                        BasicText(
-                            text = pickerState.selectedDate.toString().uppercase(),
-                            style = Carbon.typography.code02.copy(color = Carbon.theme.textPrimary)
-                        )
-                    }
-                }
-            }
         },
         modifier = modifier
     )
+}
+
+@Composable
+private fun FieldDebugSection(
+    isFieldValid: Boolean?,
+    inputValue: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .layerBackground()
+            .padding(SpacingScale.spacing05),
+        verticalArrangement = Arrangement.spacedBy(SpacingScale.spacing03)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            BasicText(
+                text = "Latest field validation event",
+                style = Carbon.typography.body01.copy(color = Carbon.theme.textHelper),
+                modifier = Modifier.padding(end = SpacingScale.spacing03)
+            )
+
+            when (isFieldValid) {
+                true -> ReadOnlyTag(
+                    text = "OK",
+                    type = TagType.Green,
+                    icon = { painterResource(Res.drawable.ic_checkmark_filled) },
+                    size = TagSize.Small
+                )
+                false -> ReadOnlyTag(
+                    text = "ERROR",
+                    type = TagType.Red,
+                    icon = { painterResource(Res.drawable.ic_warning_filled) },
+                    size = TagSize.Small
+                )
+                null -> ReadOnlyTag(
+                    text = "EMPTY",
+                    type = TagType.Gray,
+                    icon = { painterResource(Res.drawable.ic_unknown_filled) },
+                    size = TagSize.Small
+                )
+            }
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            BasicText(
+                text = "Selected date",
+                style = Carbon.typography.body01.copy(color = Carbon.theme.textHelper),
+                modifier = Modifier.padding(end = SpacingScale.spacing03)
+            )
+
+            BasicText(
+                text = inputValue,
+                style = Carbon.typography.code02.copy(color = Carbon.theme.textPrimary)
+            )
+        }
+    }
 }

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -28,7 +28,7 @@
   - [Default content switcher](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.contentswitcher/-content-switcher.html)
   - [Icon content switcher](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.contentswitcher/-icon-content-switcher.html)
 - Date picker
-  - [Simple date picker](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.datepicker/-simple-date-input.html) 
+  - [Simple date input](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.datepicker/-simple-date-input.html) 
   - [Single with calendar](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.datepicker/-calendar-date-picker.html)
 - Dropdown
     - [Default dropdown](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.dropdown/-dropdown.html)

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -28,6 +28,7 @@
   - [Default content switcher](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.contentswitcher/-content-switcher.html)
   - [Icon content switcher](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.contentswitcher/-icon-content-switcher.html)
 - Date picker
+  - [Simple date picker](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.datepicker/-simple-date-input.html) 
   - [Single with calendar](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.datepicker/-calendar-date-picker.html)
 - Dropdown
     - [Default dropdown](https://gabrieldrn.github.io/carbon-compose/api/carbon/com.gabrieldrn.carbon.dropdown/-dropdown.html)


### PR DESCRIPTION
<!-- 

  /!\ Important

  For changes on Carbon components, ensure the following:
  - Every component **variant** you have newly implemented/modified...:
    - Answers **all** specifications from official Carbon documentation website in terms of:
      - Theming: Colors with themes and layers.
      - Interactions: By mouse, keyboard and touch inputs.
      - Accessibility (guidelines & interactions).
      - Etc.
    - Is Unit & UI tested.
    - Is presented in a demo screen in the `:catalog` app module.
  - The API signature is updated (run `./gradlew apiDump`)
  - Public declarations are documented with KDoc blocs.
  - You have addressed all static code analysis issues (Detekt: run `./gradlew detekt`).
  - The documentation (MK docs + Dokka) is updated.

-->

<!--

  /!\ Important

  When creating your pull request, don't forget to link the related issue from the project's board:
    => https://github.com/users/gabrieldrn/projects/3
  You can add this link with the options on the right panel.

-->

# Notes / Description

This pull request introduces a new "Simple Date Input" component to the Carbon date picker suite, providing a text-based date entry field with validation and formatting support. The implementation includes the main composable, its state management, and comprehensive tests. Additionally, the new component is integrated into the catalog demo screen for demonstration purposes.

**New Simple Date Input Component:**

* Added the `SimpleDateInput` composable, which allows users to type dates directly into a text field, with support for placeholder, helper text, and input state (enabled, error, disabled, read-only). This component delegates parsing and formatting to a state object and provides accessibility semantics.
* Introduced `SimpleDateInputState` and its implementation, handling date parsing, formatting, validation callbacks, and state restoration via Compose's `Saver`. Includes a `rememberSimpleDateInputState` function for lifecycle-aware state management.

**Testing:**

* Created `SimpleDateInputTest` with extensive unit tests for layout, semantics, validation, state restoration, and programmatic updates, ensuring robustness and correct behavior of the new component.

**Catalog Integration:**

* Updated imports in `DatePickerDemoScreen.kt` to include `SimpleDateInput` and its state, preparing the catalog for a demo of the new component.

# Platforms testing checklist

<!-- 
  Ensure you have tested your changes with all the platforms available to you.
  Check the platforms you have tested onto in the list below. For the platforms you couldn't test, 
  add the mention "(needs test)" next to them. Project maintainers will run tests on all platforms to validate
  your changes anyway but it will make them pay extra attention on those platforms specifically.
-->

- [x] Android
- [x] iOS
- [x] Desktop
  - [ ] Linux
  - [x] Apple
  - [ ] Windows
- [x] WASM

# Screenshots / videos

<!-- Add a few media to present your changes -->
